### PR TITLE
MLRun Env Refactor + Version Bumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/*
+charts/mlrun-ce/charts/*

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.0.9
+version: 0.0.10
 name: mlrun-ce
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/override-full.yaml
+++ b/charts/mlrun-ce/override-full.yaml
@@ -15,31 +15,9 @@ mlrun:
       enabled: true
       annotations:
         helm.sh/resource-policy: "keep"
-    extraEnv:
-      - name: MLRUN_SPARK_OPERATOR_VERSION
-        value: spark-3
-      - name: MLRUN_STORAGE__AUTO_MOUNT_TYPE
-        value: s3
-      - name: MLRUN_STORAGE__AUTO_MOUNT_PARAMS
-        value: "aws_access_key=minio,aws_secret_key=minio123,endpoint_url=http://minio.mlrun.svc.cluster.local:9000"
-      - name: MLRUN_HTTPDB__PROJECTS__FOLLOWERS
-        value: nuclio
-      - name: S3_ENDPOINT_URL
-        value: http://minio.mlrun.svc.cluster.local:9000
-      - name: AWS_SECRET_ACCESS_KEY
-        value: minio123
-      - name: AWS_ACCESS_KEY_ID
-        value: minio
-      - name: MLRUN_HTTPDB__REAL_PATH
-        value: s3://
-      - name: MLRUN_ARTIFACT_PATH
-        value: s3://mlrun/
-      - name: MLRUN_SPARK_APP_IMAGE
-        value: gcr.io/iguazio/spark-app
-      - name: MLRUN_SPARK_APP_IMAGE_TAG
-        value: v3.2.1-mlk
-      - name: MLRUN_KFP_URL
-        value: http://ml-pipeline.mlrun.svc.cluster.local:8888
+    envFrom:
+      - configMapRef:
+          name: mlrun-override-full-env
   db:
     persistence:
       enabled: true

--- a/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mlrun-override-full-env
+data:
+  MLRUN_SPARK_OPERATOR_VERSION: spark-3
+  MLRUN_SPARK_APP_IMAGE: gcr.io/iguazio/spark-app
+  MLRUN_SPARK_APP_IMAGE_TAG: v3.2.1-mlk
+  MLRUN_KFP_URL: http://ml-pipeline.mlrun.svc.cluster.local:8888

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -18,13 +18,13 @@ nuclio:
   controller:
     enabled: true
     image:
-      tag: 1.10.1-amd64
+      tag: 1.10.4-amd64
   dashboard:
     enabled: true
 
     # nodePort - taken from global.nuclio.dashboard.nodePort for re-usability
     image:
-      tag: 1.10.1-amd64
+      tag: 1.10.4-amd64
 
     # k8s has deprecated docker support since v1.20
     containerBuilderKind: kaniko
@@ -77,7 +77,7 @@ mlrun:
   api:
     fullnameOverride: mlrun-api
     image:
-      tag: 1.1.0-rc26
+      tag: 1.1.0-rc30
     service:
       type: NodePort
       nodePort: 30070
@@ -93,8 +93,6 @@ mlrun:
       size: "8Gi"
       annotations: ~
     extraEnv:
-      - name: MLRUN_KFP_URL
-        value: http://ml-pipeline.mlrun.svc.cluster.local:8888
       - name: MLRUN_STORAGE__AUTO_MOUNT_TYPE
         value: s3
       - name: MLRUN_STORAGE__AUTO_MOUNT_PARAMS
@@ -118,7 +116,7 @@ mlrun:
       type: NodePort
       nodePort: 30060
     image:
-      tag: 1.1.0-rc26
+      tag: 1.1.0-rc30
   db:
     name: db
     fullnameOverride: mlrun-db
@@ -170,7 +168,7 @@ jupyterNotebook:
     #      - chart-example.local
   image:
     repository: quay.io/mlrun/jupyter
-    tag: 1.1.0-rc26
+    tag: 1.1.0-rc30
     pullPolicy: IfNotPresent
 
   # use this to override mlrunUIURL, by default it will be auto-resolved to externalHostAddress and


### PR DESCRIPTION
- Added `mlrun-override-full-env` config map which holds the full ce mlrun api config, the rest of the mlrun api config is common to all the flavors and exists in the `extraEnv` of the `values.yaml` file.
- Fixed lite version to not expect pipelines
- Bump MLRun & Nuclio Versions