### PR TITLE
PyTorch Tensorboard Logs Workaround

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.0.21
+version: 0.0.22
 name: mlrun-ce
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
@@ -12,3 +12,4 @@ data:
   MLRUN_HTTPDB__REAL_PATH: s3://
   MLRUN_ARTIFACT_PATH: s3://mlrun/
   MLRUN_CE__MODE: {{ .Values.mlrun.ce.mode }}
+  MLRUN_DEFAULT_TENSORBOARD_LOGS_PATH: /home/jovyan/data/tensorboard/{{project}}


### PR DESCRIPTION
pytorch currently isn't working properly with S3. Tensorflow has a sub-pakcage called tensorflow-io that aims to write for s3. however, that will require overriding PyTorch’s own code that uses tensorboard. 

For now our workaround is to set the tensorboard log dir to a local path in the jupyter pod.