### PR TITLE
Fix un-escaped curly brackets

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.0.22
+version: 0.0.23
 name: mlrun-ce
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
@@ -12,4 +12,4 @@ data:
   MLRUN_HTTPDB__REAL_PATH: s3://
   MLRUN_ARTIFACT_PATH: s3://mlrun/
   MLRUN_CE__MODE: {{ .Values.mlrun.ce.mode }}
-  MLRUN_DEFAULT_TENSORBOARD_LOGS_PATH: /home/jovyan/data/tensorboard/{{project}}
+  MLRUN_DEFAULT_TENSORBOARD_LOGS_PATH: /home/jovyan/data/tensorboard/{{ `{{project}} `}}


### PR DESCRIPTION
`{{ }}` double curly-brackets are saved markings in helm, so we need to escape them with extra `{{ }}` double curly-brackets in order for helm to parse the value correctly