### PR TITLE
Nuclio - install as namespaced component

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.2-rc2
+version: 0.5.2-rc3
 name: mlrun-ce
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/README.md
+++ b/charts/mlrun-ce/README.md
@@ -191,7 +191,8 @@ Your applications are now available in your local browser:
 helm --namespace mlrun uninstall my-mlrun
 ```
 
-#### Note on terminating pods and hanging resources
+### Terminating pods and hanging resources
+
 It is important to note that this chart generates several persistent volume claims and also provisions an NFS
 provisioning server, to provide the user with persistency (via pvc) out of the box.
 Because of the persistency of PV/PVC resources, after installing this chart, PVs and PVCs will be created,

--- a/charts/mlrun-ce/requirements.lock
+++ b/charts/mlrun-ce/requirements.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: nuclio
   repository: https://nuclio.github.io/nuclio/charts
-  version: 0.16.8
+  version: 0.16.9
 - name: mlrun
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.9.1
+  version: 0.9.4
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.6.0
@@ -17,5 +17,5 @@ dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 41.7.2
-digest: sha256:4578d8994303127570c6218b17355545a9fc9e7d401a6b60d13e1e31e3eea32c
-generated: "2023-01-08T12:16:00.731185+02:00"
+digest: sha256:9f8ffda74734ba98e1206d56a182d5b6060fd4e46cfb3f50991ab3f89e87d34d
+generated: "2023-01-15T14:09:09.210445+02:00"

--- a/charts/mlrun-ce/requirements.yaml
+++ b/charts/mlrun-ce/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: nuclio
-  version: "0.16.8"
+  version: "0.16.9"
   repository: "https://nuclio.github.io/nuclio/charts"
 - name: mlrun
-  version: "0.9.1"
+  version: "0.9.4"
   repository: "https://v3io.github.io/helm-charts/stable"
 - name: mpi-operator
   version: "0.6.0"

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -33,7 +33,9 @@ nuclio:
     enabled: false
   rbac:
     create: true
-    crdAccessMode: cluster
+
+    # do not allow nuclio to listen on all namespaces
+    crdAccessMode: namespaced
   crd:
     create: true
   platform:


### PR DESCRIPTION
When installing CE, we default to run on specific namespace and not letting nuclio controller to act against any CRD created cross cluster