### PR TITLE
Bump Nuclio to 1.11.15

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.0-rc1
+version: 0.6.0-rc2
 name: mlrun-ce
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/requirements.yaml
+++ b/charts/mlrun-ce/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: nuclio
-  version: "0.17.4"
+  version: "0.17.5"
   repository: "https://nuclio.github.io/nuclio/charts"
 - name: mlrun
   version: "0.9.10"

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -17,13 +17,13 @@ nuclio:
   controller:
     enabled: true
     image:
-      tag: 1.11.14-amd64
+      tag: 1.11.15-amd64
   dashboard:
     enabled: true
 
     # nodePort - taken from global.nuclio.dashboard.nodePort for re-usability
     image:
-      tag: 1.11.14-amd64
+      tag: 1.11.15-amd64
 
     # k8s has deprecated docker support since v1.20
     containerBuilderKind: kaniko


### PR DESCRIPTION
Release: https://github.com/nuclio/nuclio/releases/tag/1.11.15 