### PR TITLE
[Jupyter] Fix MLRun SDK Config

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.0-rc3
+version: 0.6.0-rc4
 name: mlrun-ce
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -191,8 +191,6 @@ jupyterNotebook:
       value: minio123
     - name: AWS_ACCESS_KEY_ID
       value: minio
-    - name: MLRUN_CE
-      value: "true"
 
   persistence:
     enabled: true


### PR DESCRIPTION
Fixes - https://jira.iguazeng.com/browse/CEML-93

The mlrun SDK wasn't syncing the mlrun config properly from the server as the `MLRUN_CE` was set to `true` while on the server it expects a dictionary and raised an exception. Now the config should sync properly and the `ce` block will be populated by the sync.