### PR TITLE
delete kubernetese service metadata like revision and generation

### DIFF
--- a/charts/mlrun-ce/templates/pipelines/crd/applications.app.k8s.io.yaml
+++ b/charts/mlrun-ce/templates/pipelines/crd/applications.app.k8s.io.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/application/pull/2
     controller-gen.kubebuilder.io/version: v0.4.0
-  generation: 1
   labels:
     controller-tools.k8s.io: "1.0"
   name: applications.app.k8s.io

--- a/charts/mlrun-ce/templates/pipelines/crd/clusterworkflowtemplates.argoproj.io.yaml
+++ b/charts/mlrun-ce/templates/pipelines/crd/clusterworkflowtemplates.argoproj.io.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-  generation: 1
   name: clusterworkflowtemplates.argoproj.io
 spec:
   conversion:

--- a/charts/mlrun-ce/templates/pipelines/crd/cronworkflows.argoproj.io.yaml
+++ b/charts/mlrun-ce/templates/pipelines/crd/cronworkflows.argoproj.io.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-#  generation: 1
   name: cronworkflows.argoproj.io
 spec:
   conversion:

--- a/charts/mlrun-ce/templates/pipelines/crd/scheduledworkflows.kubeflow.org.yaml
+++ b/charts/mlrun-ce/templates/pipelines/crd/scheduledworkflows.kubeflow.org.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-#  generation: 1
   name: scheduledworkflows.kubeflow.org
 spec:
   conversion:

--- a/charts/mlrun-ce/templates/pipelines/crd/viewers.kubeflow.org.yaml
+++ b/charts/mlrun-ce/templates/pipelines/crd/viewers.kubeflow.org.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-#  generation: 1
   name: viewers.kubeflow.org
 spec:
   conversion:

--- a/charts/mlrun-ce/templates/pipelines/crd/workfloweventbindings.argoproj.io.yaml
+++ b/charts/mlrun-ce/templates/pipelines/crd/workfloweventbindings.argoproj.io.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-#  generation: 1
   name: workfloweventbindings.argoproj.io
 spec:
   conversion:

--- a/charts/mlrun-ce/templates/pipelines/crd/workflows.argoproj.io.yaml
+++ b/charts/mlrun-ce/templates/pipelines/crd/workflows.argoproj.io.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-#  generation: 1
   name: workflows.argoproj.io
 spec:
   conversion:

--- a/charts/mlrun-ce/templates/pipelines/crd/workflowtaskresults.argoproj.io.yaml
+++ b/charts/mlrun-ce/templates/pipelines/crd/workflowtaskresults.argoproj.io.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-#  generation: 1
   name: workflowtaskresults.argoproj.io
 spec:
   conversion:

--- a/charts/mlrun-ce/templates/pipelines/crd/workflowtasksets.argoproj.io.yaml
+++ b/charts/mlrun-ce/templates/pipelines/crd/workflowtasksets.argoproj.io.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-#  generation: 1
   name: workflowtasksets.argoproj.io
 spec:
   conversion:

--- a/charts/mlrun-ce/templates/pipelines/crd/workflowtemplates.argoproj.io.yaml
+++ b/charts/mlrun-ce/templates/pipelines/crd/workflowtemplates.argoproj.io.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-#  generation: 1
   name: workflowtemplates.argoproj.io
 spec:
   conversion:

--- a/charts/mlrun-ce/templates/pipelines/deployments/metadata-envoy-deployment.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/metadata-envoy-deployment.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     application-crd-id: kubeflow-pipelines
     component: metadata-envoy

--- a/charts/mlrun-ce/templates/pipelines/deployments/metadata-grpc-deployment.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/metadata-grpc-deployment.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     application-crd-id: kubeflow-pipelines
     component: metadata-grpc-server

--- a/charts/mlrun-ce/templates/pipelines/deployments/metadata-writer.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/metadata-writer.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     app: metadata-writer
     application-crd-id: kubeflow-pipelines

--- a/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-persistenceagent.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-persistenceagent.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     app: ml-pipeline-persistenceagent
     application-crd-id: kubeflow-pipelines

--- a/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-scheduledworkflow.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-scheduledworkflow.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     app: ml-pipeline-scheduledworkflow
     application-crd-id: kubeflow-pipelines

--- a/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-ui.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-ui.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     app: ml-pipeline-ui
     application-crd-id: kubeflow-pipelines

--- a/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-viewer-crd.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-viewer-crd.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     app: ml-pipeline-viewer-crd
     application-crd-id: kubeflow-pipelines

--- a/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-visualizationserver.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-visualizationserver.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     app: ml-pipeline-visualizationserver
     application-crd-id: kubeflow-pipelines

--- a/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     app: ml-pipeline
     application-crd-id: kubeflow-pipelines

--- a/charts/mlrun-ce/templates/pipelines/deployments/mysql.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/mysql.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     app: mysql
     application-crd-id: kubeflow-pipelines

--- a/charts/mlrun-ce/templates/pipelines/deployments/workflow-controller.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/workflow-controller.yaml
@@ -2,9 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     application-crd-id: kubeflow-pipelines
   name: workflow-controller

--- a/charts/mlrun-ce/templates/pipelines/priorityclass.scheduling.k8s.io/workflow-controller.yaml
+++ b/charts/mlrun-ce/templates/pipelines/priorityclass.scheduling.k8s.io/workflow-controller.yaml
@@ -2,8 +2,6 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  annotations:
-  generation: 1
   labels:
     application-crd-id: kubeflow-pipelines
   name: workflow-controller


### PR DESCRIPTION
Deleted fields are populated by k8s itself and should not be present in helm charts or plain manifests.