### PR TITLE
Allow overriding Jupyter busybox image source

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.3-rc14
+version: 0.6.3-rc15
 name: mlrun-ce
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/templates/jupyter-notebook/deployment.yaml
+++ b/charts/mlrun-ce/templates/jupyter-notebook/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       - name: init-chown-data
         # jupyter default NB user: uid=1000(jovyan) gid=100(users) groups=100(users)
         command: ["chown", "-R", "1000:100", "/home/jovyan/"]
-        image: busybox:1.35
+        image: "{{ .Values.jupyterNotebook.busybox.image }}:{{ .Values.jupyterNotebook.busybox.tag }}"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -176,6 +176,9 @@ jupyterNotebook:
     repository: quay.io/mlrun/jupyter
     tag: 1.6.1
     pullPolicy: IfNotPresent
+  busybox:
+    image: busybox
+    tag: 1.35
 
   # use this to override mlrunUIURL, by default it will be auto-resolved to externalHostAddress and
   # mlrun UI's node port


### PR DESCRIPTION
Frequent lab deployments cause rate limit from docker.io. This is the only image that was not exposed in values.yaml