### PR TITLE
[Pipelines] Include new permissions to the ML Pipeline's Persistence Agent

### DIFF
--- a/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-persistenceagent.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline-persistenceagent.yaml
@@ -48,6 +48,17 @@ spec:
             memory: 500Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /var/run/secrets/kubeflow/tokens
+            name: persistenceagent-sa-token
+      volumes:
+        - name: persistenceagent-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: persistenceagent-sa-token
+                  expirationSeconds: 3600
+                  audience: pipelines.kubeflow.org
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/charts/mlrun-ce/templates/pipelines/roles/ml-pipeline-persistenceagent-role.yaml
+++ b/charts/mlrun-ce/templates/pipelines/roles/ml-pipeline-persistenceagent-role.yaml
@@ -23,4 +23,17 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - scheduledworkflows
+  - workflows
+  verbs:
+  - report
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
 {{- end -}}


### PR DESCRIPTION
The new permissions added here enable this Helm Chart to also support KFP Pipelines v2 (in addition to v1.8).