### PR TITLE
AWS unified ingress

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.3-rc19
+version: 0.6.3-rc20
 name: mlrun-ce
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/templates/_helpers.tpl
+++ b/charts/mlrun-ce/templates/_helpers.tpl
@@ -226,3 +226,14 @@ Model monitoring DSN
 {{- end -}}
 {{- end -}}
 
+{{/*
+serviceAccounts for AWS
+*/}}
+{{- define "aws.serviceAccounts" -}}
+mlrun-api-aws-sa
+mlrun-jobs-aws-sa
+ml-pipeline-ui-sa
+ml-pipeline-sa
+argo-sa
+{{- end -}}
+

--- a/charts/mlrun-ce/templates/_helpers.tpl
+++ b/charts/mlrun-ce/templates/_helpers.tpl
@@ -227,6 +227,7 @@ Model monitoring DSN
 {{- end -}}
 
 {{/*
+TODO: Remove when dust settles, probably not needed
 serviceAccounts for AWS
 */}}
 {{- define "aws.serviceAccounts" -}}

--- a/charts/mlrun-ce/templates/aws/aws_ingress.yaml
+++ b/charts/mlrun-ce/templates/aws/aws_ingress.yaml
@@ -1,0 +1,68 @@
+{{- if eq .Values.global.infrastructure.provider "aws" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mlrun-ce-ingress
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+  {{- if .Values.global.domainNameCertificate }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.global.domainNameCertificate }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+  {{- else }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+  {{- end }}
+spec:
+  ingressClassName: alb
+  rules:
+    - host: mlrun.{{ .Values.global.externalHostAddress }}
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: mlrun-ui
+                port:
+                  number: 80
+    - host: mlrun-api.{{ .Values.global.externalHostAddress }}
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: mlrun-api
+                port:
+                  number: 8080
+    - host: nuclio.{{ .Values.global.externalHostAddress }}
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nuclio-dashboard
+                port:
+                  number: 8070
+    - host: jupyter.{{ .Values.global.externalHostAddress }}
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: mlrun-jupyter
+                port:
+                  number: 80
+    - host: grafana.{{ .Values.global.externalHostAddress }}
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 80
+{{- end }}

--- a/charts/mlrun-ce/templates/jupyter-notebook/ingress.yaml
+++ b/charts/mlrun-ce/templates/jupyter-notebook/ingress.yaml
@@ -17,7 +17,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: nginx
 {{- if .Values.jupyterNotebook.ingress.tls }}
   tls:
   {{- range .Values.jupyterNotebook.ingress.tls }}

--- a/charts/mlrun-ce/templates/jupyter-notebook/ingress.yaml
+++ b/charts/mlrun-ce/templates/jupyter-notebook/ingress.yaml
@@ -17,6 +17,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: nginx
 {{- if .Values.jupyterNotebook.ingress.tls }}
   tls:
   {{- range .Values.jupyterNotebook.ingress.tls }}

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -418,8 +418,3 @@ kube-prometheus-stack:
   prometheus-node-exporter:
     fullnameOverride: node-exporter
 
-cloud:
-  aws:
-    enabled: false
-    roleArn: ~
-

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -417,3 +417,9 @@ kube-prometheus-stack:
     fullnameOverride: state-metrics
   prometheus-node-exporter:
     fullnameOverride: node-exporter
+
+cloud:
+  aws:
+    enabled: false
+    roleArn: ~
+


### PR DESCRIPTION
Added unified ingress file for 5 services:
* mlrun-ui
* mlrun-api
* jupyter
* grafana
* nuclio
to use with AWS ALB (same as it was implemented in CFN stack)