### PR TITLE
[Chart] Remove image overrides

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.6.3-rc23
-appVersion: 1.6.4
+version: 0.6.3-rc24
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/README.md
+++ b/charts/mlrun-ce/README.md
@@ -278,6 +278,6 @@ Refer to the [**Kubeflow documentation**](https://www.kubeflow.org/docs/started/
 
 This table shows the versions of the main components in the MLRun CE chart:
 
-| MLRun CE Version | MLRun Version | Nuclio Version | Jupyter Version | MPI Operator Version | Minio Version                | Spark Operator Version | Pipelines Version | Prometheus Version |
-|------------------|---------------|----------------|-----------------|----------------------|------------------------------|------------------------|-------------------|--------------------|
-| **0.6.3**        | 1.6.4         | 1.13.5         | 6.4.0           | 0.2.3                | RELEASE.2022-05-08T23-50-31Z | v1beta2-1.1.25         | 1.8.1             | 17.0.0             |
+| MLRun CE  | MLRun | Nuclio | Jupyter | MPI Operator | Minio                        | Spark Operator | Pipelines | Kube-Prometheus-Stack | Prometheus | Grafana |
+|-----------|-------|--------|---------|--------------|------------------------------|----------------|-----------|-----------------------|------------|---------|
+| **0.6.3** | 1.6.4 | 1.13.5 | 6.4.0   | 0.2.3        | RELEASE.2022-05-08T23-50-31Z | v1beta2-1.1.25 | 1.8.1     | 17.0.0                | 2.39.1     | 6.40.4  |

--- a/charts/mlrun-ce/README.md
+++ b/charts/mlrun-ce/README.md
@@ -272,3 +272,12 @@ $ rm -rf my-mlrun-mlrun-ce-mlrun
 MLRun enables you to run your functions while saving outputs and artifacts in a way that is visible to Kubeflow Pipelines.
 If you wish to use this capability you will need to install Kubeflow on your cluster.
 Refer to the [**Kubeflow documentation**](https://www.kubeflow.org/docs/started/getting-started/) for more information.
+
+
+## Version Matrix
+
+This table shows the versions of the main components in the MLRun CE chart:
+
+| MLRun CE Version | MLRun Version | Nuclio Version | Jupyter Version | MPI Operator Version | Minio Version                | Spark Operator Version | Pipelines Version | Prometheus Version |
+|------------------|---------------|----------------|-----------------|----------------------|------------------------------|------------------------|-------------------|--------------------|
+| **0.6.3**        | 1.6.4         | 1.13.5         | 6.4.0           | 0.2.3                | RELEASE.2022-05-08T23-50-31Z | v1beta2-1.1.25         | 1.8.1             | 17.0.0             |

--- a/charts/mlrun-ce/requirements.lock
+++ b/charts/mlrun-ce/requirements.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: nuclio
   repository: https://nuclio.github.io/nuclio/charts
-  version: 0.18.15
+  version: 0.19.5
 - name: mlrun
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.9.23
+  version: 0.9.26
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.6.0
@@ -17,5 +17,5 @@ dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 41.7.2
-digest: sha256:7f8dc88caa72582f10839c08e984f06cfee658823ed35a657795a4e1723ca1d6
-generated: "2024-05-08T10:01:32.782891+03:00"
+digest: sha256:1f953d3ffae61e60f38295a7425bda95cbe31b2d7e5b6da5bcbfb952aae7ccf3
+generated: "2024-07-11T09:58:55.765082+03:00"

--- a/charts/mlrun-ce/requirements.yaml
+++ b/charts/mlrun-ce/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: nuclio
-    version: "0.18.15"
+    version: "0.19.5"
     repository: "https://nuclio.github.io/nuclio/charts"
   - name: mlrun
-    version: "0.9.25"
+    version: "0.9.26"
     repository: "https://v3io.github.io/helm-charts/stable"
     condition: mlrun.enabled
   - name: mpi-operator

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -17,14 +17,9 @@ nuclio:
   fullnameOverride: nuclio
   controller:
     enabled: true
-    image:
-      tag: 1.12.14-amd64
   dashboard:
     enabled: true
-
     # nodePort - taken from global.nuclio.dashboard.nodePort for re-usability
-    image:
-      tag: 1.12.14-amd64
 
     # k8s has deprecated docker support since v1.20
     containerBuilderKind: kaniko
@@ -81,11 +76,7 @@ mlrun:
     sidecars:
       logCollector:
         enabled: true
-        image:
-          tag: 1.6.4
     fullnameOverride: mlrun-api
-    image:
-      tag: 1.6.4
     service:
       type: NodePort
       nodePort: 30070
@@ -119,8 +110,6 @@ mlrun:
     service:
       type: NodePort
       nodePort: 30060
-    image:
-      tag: 1.6.4
   db:
     name: db
     fullnameOverride: mlrun-db


### PR DESCRIPTION
The images for each component of the CE stack are determined in their respective charts.
Instead of overriding the images explicitly in the values file, simply use the correct charts.

In this PR:
1. Remove the image overrides
2. Align to the latest MLRun and Nuclio chart versions
3. Add a version matrix to the README