### PR TITLE
[Charts] Fix admin charts

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.6.3-rc24
+version: 0.6.3-rc25
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/admin_installation_values.yaml
+++ b/charts/mlrun-ce/admin_installation_values.yaml
@@ -17,13 +17,17 @@ nuclio:
     enabled: false
   rbac:
     create: false
-  platform: false
+  platform: null
 
 mlrun:
   enabled: false
 
 jupyterNotebook:
   enabled: false
+  serviceAccount:
+    create: false
+  persistence:
+    enabled: false
 
 mpi-operator:
   rbac:

--- a/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml
+++ b/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml
@@ -20,6 +20,7 @@ mlrun:
     service:
       type: ClusterIP
       nodePort: ""
+
 jupyterNotebook:
   service:
     type: ClusterIP
@@ -49,7 +50,7 @@ spark-operator:
 
 pipelines:
   service:
-    type : ClusterIP
+    type: ClusterIP
     nodePort: ""
   crd:
     enabled: false

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -147,7 +147,7 @@ jupyterNotebook:
   serviceAccount:
     create: true
     name: mlrun-jupyter
-  awsInstall: false 
+  awsInstall: false
   fullnameOverride: mlrun-jupyter
   name: jupyter-notebook
   enabled: true
@@ -194,7 +194,7 @@ jupyterNotebook:
   envFrom:
     - configMapRef:
         name: jupyter-common-env
-        optional: true        
+        optional: true
   persistence:
     enabled: true
     existingClaim:
@@ -253,7 +253,7 @@ spark-operator:
   enabled: true
   fullnameOverride: spark-operator
   webhook:
-     enable: true
+    enable: true
   serviceAccounts:
     spark:
       name: "sparkapp"
@@ -409,4 +409,3 @@ kube-prometheus-stack:
     fullnameOverride: state-metrics
   prometheus-node-exporter:
     fullnameOverride: node-exporter
-


### PR DESCRIPTION
Admin chart created pvc / service account for jupyter
and its default "false" for platform config yield some errors - change to `null` to ensure the field is omitted from its default values.yaml - the result as expected - no configmap is created.
