### PR TITLE
AWS ALB: add inboundCidrs + ALB name, configure ssl-redirect if certificate provided

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.6.3-rc27
+version: 0.6.3-rc28
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/aws/aws_ingress.yaml
+++ b/charts/mlrun-ce/templates/aws/aws_ingress.yaml
@@ -6,9 +6,16 @@ metadata:
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
+  {{- if .Values.global.infrastructure.inboundCidrs }}
+    alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.global.infrastructure.inboundCidrs }}
+  {{- end }}  
+  {{- if .Values.global.infrastructure.loadBalancerName }}
+    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.global.infrastructure.loadBalancerName }}
+  {{- end }}
   {{- if .Values.global.domainNameCertificate }}
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.global.domainNameCertificate }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
   {{- else }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
   {{- end }}

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -11,6 +11,8 @@ global:
   infrastructure:
     kind: lab
     provider: ~
+    inboundCidrs: ~
+    loadBalancerName: ~
 
 nuclio:
   # coupled with mlrun.nuclio.dashboardName template in mlrun chart


### PR DESCRIPTION
AWS ALB:
- Option to configure ALB inbound CIDRs
- Option to configure ALB name
- Configure ssl-redirect if certificate is provided