### PR TITLE
[Prometheus] Remove model monitoring scraping configuration

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.6.4-rc1
+version: 0.6.4-rc3
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.6.3
+version: 0.6.4-rc1
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -382,42 +382,6 @@ kube-prometheus-stack:
     service:
       type: NodePort
       nodePort: 30020
-    prometheusSpec:
-      storageSpec:
-        volumeClaimTemplate:
-          spec:
-            storageClassName: local-path
-            accessModes: ["ReadWriteOnce"]
-            resources:
-              requests:
-                storage: 5Gi
-      additionalScrapeConfigs:
-        - job_name: model-monitoring-job
-          metrics_path: /model-monitoring-metrics
-          scheme: http
-          tls_config:
-            insecure_skip_verify: true
-          scrape_interval: 30s
-          scrape_timeout: 10s
-          relabel_configs:
-            - source_labels: [__meta_kubernetes_namespace]
-              separator: ;
-              regex: (.*)
-              target_label: namespace
-              replacement: $1
-              action: replace
-          kubernetes_sd_configs:
-            - role: pod
-              kubeconfig_file: ""
-              follow_redirects: true
-              enable_http2: true
-              namespaces:
-                own_namespace: false
-                names:
-                  - mlrun
-              selectors:
-                - role: "pod"
-                  label: "type=model-monitoring-stream"
   kube-state-metrics:
     fullnameOverride: state-metrics
   prometheus-node-exporter:


### PR DESCRIPTION
Following https://github.com/mlrun/mlrun/pull/6074, prometheus is no longer supported as a TSDB solution for model monitoring. In this PR we remove the model monitoring scraping configuration which is no longer needed. 

Related JIRA: https://iguazio.atlassian.net/browse/CEML-215