### PR TITLE
Bump MinIO chart

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.6.4-rc3
+version: 0.6.4-rc4
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/requirements.lock
+++ b/charts/mlrun-ce/requirements.lock
@@ -10,12 +10,12 @@ dependencies:
   version: 0.6.0
 - name: minio
   repository: https://charts.min.io/
-  version: 4.0.15
+  version: 5.2.0
 - name: spark-operator
   repository: https://kubeflow.github.io/spark-operator
   version: 1.1.25
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 41.7.2
-digest: sha256:73bece54391f002748e13f32170e76bd8a049d23fd1e321e910d1f5be707a4a4
-generated: "2024-08-11T10:51:07.577058+03:00"
+digest: sha256:3d6ddc1f2ec2e46233378b3e69ef2f99b6677f505faf4d5a384c10b032bea9b0
+generated: "2024-08-13T10:13:52.148247+03:00"

--- a/charts/mlrun-ce/requirements.yaml
+++ b/charts/mlrun-ce/requirements.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: "https://v3io.github.io/helm-charts/stable"
   - name: minio
     repository: "https://charts.min.io/"
-    version: "4.0.15"
+    version: "5.2.0"
     condition: minio.enabled
   - name: spark-operator
     repository: "https://kubeflow.github.io/spark-operator"


### PR DESCRIPTION
MinIO fails (sporadically? randomly? HW-dependent?) to create a bucket with this error:
1: internal/sync/errgroup/errgroup.go:123:errgroup.(*Group).Go.func1()
Waiting for all MinIO sub-systems to be initialized.. possible cause (Unable to initialize config system: migrateConfigToMinioSys: Storage resources are insufficient for the write operation .minio.sys/config/config.json)
According to this git convo it's an old bug that has been resolved a year ago:
https://github.com/minio/minio/discussions/17875
Bumping chart version to 5.2.0 resolves this issue.