### PR TITLE
[Values] Add run uid to default artifact path

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.6.4-rc7
+version: 0.6.4-rc8
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -192,7 +192,7 @@ jupyterNotebook:
   mlrunUIURL:
   extraEnv:
     - name: MLRUN_ARTIFACT_PATH
-      value: s3://mlrun/projects/{{run.project}}/artifacts
+      value: s3://mlrun/projects/{{run.project}}/artifacts/{{run.uid}}
     - name: MLRUN_FEATURE_STORE__DATA_PREFIXES__DEFAULT
       value: s3://mlrun/projects/{project}/FeatureStore/{name}/{kind}
     - name: MLRUN_FEATURE_STORE__DATA_PREFIXES__NOSQL


### PR DESCRIPTION
Align the default artifact path with Iguazio, to include the run uid.

Resolves https://iguazio.atlassian.net/browse/CEML-228