### PR TITLE
[Prometheus] Disable Node Exporter

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.6.4-rc11
+version: 0.6.4-rc12
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml
+++ b/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml
@@ -58,6 +58,3 @@ pipelines:
     enabled: false
   priority_class:
     enabled: false
-
-kube-prometheus-stack:
-  enabled: false

--- a/charts/mlrun-ce/non_admin_installation_values.yaml
+++ b/charts/mlrun-ce/non_admin_installation_values.yaml
@@ -57,6 +57,3 @@ pipelines:
     enabled: false
   priority_class:
     enabled: false
-
-kube-prometheus-stack:
-  enabled: false

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -382,5 +382,5 @@ kube-prometheus-stack:
       nodePort: 30020
   kube-state-metrics:
     fullnameOverride: state-metrics
-  prometheus-node-exporter:
-    fullnameOverride: node-exporter
+  nodeExporter:
+    enabled: false


### PR DESCRIPTION
For non-admin installations and for docker-for-desktop installations, node-exporter is not available to install. However, it isn't needed in general for CE. So disabling it everywhere and enabling prometheus stack for non-admin installation.