### PR TITLE
[Model Monitoring] Delete `MLRUN_MODEL_ENDPOINT_MONITORING__STORE_TYPE` from env config

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.6.4-rc11
+version: 0.6.4-rc12
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
@@ -23,7 +23,6 @@ data:
   MLRUN_CE__VERSION: {{ .Chart.Version }}
   MLRUN_DEFAULT_TENSORBOARD_LOGS_PATH: /home/jovyan/data/tensorboard/{{ `{{project}} `}}
   MLRUN_FEATURE_STORE__DEFAULT_TARGETS: parquet
-  MLRUN_MODEL_ENDPOINT_MONITORING__STORE_TYPE: sql
   MLRUN_MODEL_ENDPOINT_MONITORING__ENDPOINT_STORE_CONNECTION: "{{ template "mlrun-ce.mlrun.modelMonitoring.DSN" . }}"
   MLRUN_GRAFANA_URL: http://{{ .Values.global.externalHostAddress }}:{{ index .Values "kube-prometheus-stack" "grafana" "service" "nodePort" }}
 {{- end}}


### PR DESCRIPTION
`MLRUN_MODEL_ENDPOINT_MONITORING__STORE_TYPE` not in use any more