### PR TITLE
[Nuclio] Run dashboard with non-root security context

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.6.4-rc14
+version: 0.6.4-rc15
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -33,6 +33,10 @@ nuclio:
     containerBuilderKind: kaniko
     ingress:
       enabled: false
+
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
   autoscaler:
     enabled: false
   dlx:


### PR DESCRIPTION
When nuclio dashboard runs as root, the function build flow creates archives in `/root/tmp/kaniko-builds` dir instead of `/tmp/kaniko-builds` which in turn fails the kaniko job.

Aligning with Iguazio and running dashboard as non-root fixed the issue.

https://iguazio.atlassian.net/browse/CEML-241