### PR TITLE
[Kafka] Kafka-OOM [TDengine] TDengine fails

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.8.0-rc7
+version: 0.8.0-rc8
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -415,7 +415,7 @@ tdengine:
   image:
     prefix: tdengine/tdengine
     pullPolicy: Always
-    tag: "3.0.2.2"
+    tag: "3.0.7.1"
   service:
     type: ClusterIP
     ports:
@@ -447,7 +447,7 @@ kafka:
 
   controller:
     replicaCount: 1
-
+    resourcesPreset: "medium"
   listeners:
     client:
       name: CLIENT


### PR DESCRIPTION
CEML-386: Kafka-stream-controller restarts due to OOM
CEML-387: TDengine crashed with taosAssert: Assertion 0 failed.

- Kafka - set resourcesPreset attribute to [medium](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L28) 
- TDengine - bump tag version to 3.0.7.1
- Bump version to 0.8.0-rc8 in Chart.yaml