### PR TITLE
Bump Nuclio chart to 0.19.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           HELM_LINT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
   artifacthub-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: artifacthub/ah
       options: --user 1001

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.8.0-rc12
+version: 0.8.0-rc13
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/requirements.lock
+++ b/charts/mlrun-ce/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: nuclio
   repository: https://nuclio.github.io/nuclio/charts
-  version: 0.19.23
+  version: 0.19.26
 - name: mlrun
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.10.8
@@ -20,5 +20,5 @@ dependencies:
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
   version: 31.3.1
-digest: sha256:daa6f5ab4e44106a88ae0c91b1d00948f1b7c5820247e259b6c4605e1147c483
-generated: "2025-03-27T21:02:19.947392+02:00"
+digest: sha256:e2610bc4b15a6dca8308200a3f75a73a2cef928deb725bc7ef89c30b6a378752
+generated: "2025-04-24T09:23:57.406616+03:00"

--- a/charts/mlrun-ce/requirements.yaml
+++ b/charts/mlrun-ce/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: nuclio
-    version: "0.19.23"
+    version: "0.19.26"
     repository: "https://nuclio.github.io/nuclio/charts"
   - name: mlrun
     version: "0.10.8"


### PR DESCRIPTION
Getting the latest https://github.com/nuclio/nuclio/releases/tag/1.13.24 