### PR TITLE
Revert "Configure MLRun as project leader in MLRun and Nuclio"

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.8.0-rc15
+version: 0.8.0-rc14
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.8.0-rc14
+version: 0.8.0-rc16
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
@@ -10,7 +10,6 @@ data:
   MLRUN_STORAGE__AUTO_MOUNT_TYPE: s3
   MLRUN_STORAGE__AUTO_MOUNT_PARAMS: {{ include "mlrun.storage.auto.mount.params" . }}
   MLRUN_HTTPDB__PROJECTS__FOLLOWERS: nuclio
-  MLRUN_HTTPDB__PROJECTS__LEADER: mlrun
 {{- if not .Values.global.infrastructure.aws.s3NonAnonymous }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.minio.rootPassword }}
   AWS_ACCESS_KEY_ID: {{ .Values.minio.rootUser }}

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -63,9 +63,6 @@ nuclio:
       functions:
         - level: debug
           sink: myStdoutLoggerSink
-      projectsLeader:
-        kind: mlrun
-        synchronizationInterval: 0m
 
 mlrun:
   # set the type of filesystem to use: filesystem, s3


### PR DESCRIPTION
Reverts mlrun/ce#188

The changes are relevant for MLRun 1.10.0 , and CE chart currently uses MLRun 1.8.0 .
This will be re-enabled when we bump MLRun.