### PR TITLE
[MLRun] Upgrade mlrun chart to 0.11.5

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.8.0-rc17
+version: 0.9.0-rc1
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/requirements.lock
+++ b/charts/mlrun-ce/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.19.26
 - name: mlrun
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.10.9
+  version: 0.11.5
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.6.0
@@ -20,5 +20,5 @@ dependencies:
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
   version: 31.3.1
-digest: sha256:d5f947b79466c870754d0e2ec674e2c3e3ae1c51e27c97fd5cf0d0b1a9b2bf2c
-generated: "2025-05-21T09:19:27.922578+03:00"
+digest: sha256:1421e035b05fa2533b612717a2ba2207d1025da52c30acb650d5c85073c2f109
+generated: "2025-06-29T11:12:10.252392+03:00"

--- a/charts/mlrun-ce/requirements.yaml
+++ b/charts/mlrun-ce/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
     version: "0.19.26"
     repository: "https://nuclio.github.io/nuclio/charts"
   - name: mlrun
-    version: "0.10.9"
+    version: "0.11.5"
     repository: "https://v3io.github.io/helm-charts/stable"
     condition: mlrun.enabled
   - name: mpi-operator

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -192,7 +192,7 @@ jupyterNotebook:
     #      - chart-example.local
   image:
     repository: quay.io/mlrun/jupyter
-    tag: 1.7.2
+    tag: 1.9.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   busybox:


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/CEML-436
This PR upgrades the mlrun chart to 0.11.5, which upgrades the default version of mlrun to 1.9.1, which supports Python 3.11.

