### PR TITLE
[Spark] Update Spark image to 3.5.6 with Python 3.11

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.9.1-rc2
+version: 0.9.1-rc3
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/config/mlrun-spark-config.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-spark-config.yaml
@@ -6,5 +6,5 @@ metadata:
 data:
   MLRUN_SPARK_OPERATOR_VERSION: spark-3
   MLRUN_SPARK_APP_IMAGE: gcr.io/iguazio/spark-app
-  MLRUN_SPARK_APP_IMAGE_TAG: v3.5.3-mlrun-ce
+  MLRUN_SPARK_APP_IMAGE_TAG: v3.5.6-mlrun-ce
 {{- end -}}


### PR DESCRIPTION
From 3.5.3 and Python 3.9.

[CEML-413](https://iguazio.atlassian.net/browse/CEML-413)

[CEML-413]: https://iguazio.atlassian.net/browse/CEML-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ