### PR TITLE
[MLRun] Add support for Grafana 11 in MLRun CE Helm chart

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.9.1-rc7
+version: 0.9.1-rc8
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/requirements.lock
+++ b/charts/mlrun-ce/requirements.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 2.1.0
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 41.7.2
+  version: 72.1.1
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
   version: 31.3.1
-digest: sha256:248d2bfb503cf7290165ced88fbb1c4756613f642fdc9d1f25dedbdca961beb4
-generated: "2025-07-29T09:44:21.12086+03:00"
+digest: sha256:1439231e374c058be8837e9d0dc5eacfcd6e6e765b51ba7ec03eeb0686e93eda
+generated: "2025-08-20T11:37:28.150996+03:00"

--- a/charts/mlrun-ce/requirements.yaml
+++ b/charts/mlrun-ce/requirements.yaml
@@ -19,7 +19,7 @@ dependencies:
     condition: spark-operator.enabled
   - name: kube-prometheus-stack
     repository: "https://prometheus-community.github.io/helm-charts"
-    version: "41.7.2"
+    version: "72.1.1"
     condition: kube-prometheus-stack.enabled
   - name: kafka
     repository: "https://charts.bitnami.com/bitnami"

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -386,6 +386,8 @@ kube-prometheus-stack:
   grafana:
     adminUser: admin
     adminPassword: admin
+    initChownData:
+      enabled: false
     additionalDataSources:
       - name: iguazio
         type: mysql


### PR DESCRIPTION
This pull request contains support for Grafana 11
kube-prometheus-stack chart should be bump due to its dependencies the LATEST version 11 (11.6.1) of Grafana

Versioning update:

Updated the chart version in charts/mlrun-ce/Chart.yaml from 0.9.1-rc7 to 0.9.1-rc8.

[CEML-268](https://iguazio.atlassian.net/browse/CEML-268)

[CEML-268]: https://iguazio.atlassian.net/browse/CEML-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ