### PR TITLE
Add AWS_ENDPOINT_URL_S3 in addition to S3_ENDPOINT_URL

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.9.1-rc3
+version: 0.9.1-rc4
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/config/jupyter-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/jupyter-env-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
 {{- if not .Values.global.infrastructure.aws.s3NonAnonymous }}
   S3_ENDPOINT_URL: {{ include "mlrun-ce.minio.service.url" . }}
+  AWS_ENDPOINT_URL_S3: {{ include "mlrun-ce.minio.service.url" . }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.minio.rootPassword }}
   AWS_ACCESS_KEY_ID: {{ .Values.minio.rootUser }}
 {{- end }}

--- a/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
@@ -13,6 +13,7 @@ data:
 {{- if not .Values.global.infrastructure.aws.s3NonAnonymous }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.minio.rootPassword }}
   AWS_ACCESS_KEY_ID: {{ .Values.minio.rootUser }}
+  AWS_ENDPOINT_URL_S3: {{ include "mlrun-ce.minio.service.url" . }}
   S3_ENDPOINT_URL: {{ include "mlrun-ce.minio.service.url" . }}
 {{- end }}
   MLRUN_FUNCTION__SPEC__SERVICE_ACCOUNT__DEFAULT: {{ .Values.mlrun.api.functionSpecServiceAccountDefault | default "" | quote }}


### PR DESCRIPTION
As part of deprecation of the S3_ENDPOINT_URL in favour of AWS_ENDPOINT_URL_S3 , add AWS_ENDPOINT_URL_S3 to the environment keys
ML-11063