### PR TITLE
[Chart] Change kafka bitnami image repository due to security change

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.9.1-rc4
+version: 0.9.1-rc5
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -450,9 +450,13 @@ tdengine:
     TAOS_REPLICA: "1"
 
 kafka:
+  global:
+    security:
+      allowInsecureImages: true
   enabled: true
   fullnameOverride: kafka-stream
-
+  image:
+    repository: 'bitnamilegacy/kafka'
   extraConfigYaml:
     default.replication.factor: "1"
     offsets.topic.replication.factor: "1"


### PR DESCRIPTION
This PR fixes - https://iguazio.atlassian.net/browse/CEML-491

The issue is a result as described [here](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications), Bitnami is changing their image and moving them to another repo, the old ones to `bitnamilegacy` and the new one to `bitnamisecure`.
For the Kafka chart, they did not release a secure image so we need to use the legacy image.

The solution is:
1. Change the repository in the `value.yaml` file 
2. As a result of this change and this [fix](https://github.com/bitnami/charts/issues/30850), we needed to add enable `allowInsecureImages` for pulling the new image