### PR TITLE
[MPI] Fix installing on separated namespace

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.9.1-rc7
+version: 0.9.1-rc8
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/non_admin_installation_values.yaml
+++ b/charts/mlrun-ce/non_admin_installation_values.yaml
@@ -33,6 +33,8 @@ mpi-operator:
   rbac:
     clusterResources:
       create: false
+    namespaced:
+      create: true
 
 minio:
   service:


### PR DESCRIPTION
This pull request contains a minor version bump for the `mlrun-ce` Helm chart and an update to the MPI Operator RBAC configuration in the non-admin installation values. These changes help ensure correct versioning and improve support for namespaced RBAC resources during installation.

Versioning update:

* Updated the chart version in `charts/mlrun-ce/Chart.yaml` from `0.9.1-rc7` to `0.9.1-rc8`.

Installation configuration improvements:

* Added `namespaced.create: true` under `mpi-operator.rbac` in `charts/mlrun-ce/non_admin_installation_values.yaml` to enable creation of namespaced RBAC resources for MPI Operator during non-admin installations.

https://iguazio.atlassian.net/browse/CEML-502