### PR TITLE
[Nuclio] Fix nuclio projectLeader configurations

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.10.0-rc10
+version: 0.10.0-rc11
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -65,7 +65,7 @@ nuclio:
           sink: myStdoutLoggerSink
     projectsLeader:
       kind: mlrun
-      synchronizationInterval: 1m
+      synchronizationInterval: 10m
       apiAddress: http://mlrun-api-chief:8080/api
 
 mlrun:

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -63,9 +63,10 @@ nuclio:
       functions:
         - level: debug
           sink: myStdoutLoggerSink
-      projectsLeader:
-        kind: mlrun
-        synchronizationInterval: 0m
+    projectsLeader:
+      kind: mlrun
+      synchronizationInterval: 1m
+      apiAddress: http://mlrun-api-chief:8080/api
 
 mlrun:
   # set the type of filesystem to use: filesystem, s3


### PR DESCRIPTION
Changes:
- Add `projectLeader` to nuclio configurations the proper way

Tests:
- Tested manually:
  - Saved the current configMap before the changes ( `kubectl -n mlrun get cm nuclio-platform-config -oyaml > nucliopc_BEFORE.yaml`)
  - Compared the configMap that was created with the changes:
  
<img width="809" height="262" alt="image" src="https://github.com/user-attachments/assets/da1b9647-0be8-4126-a49e-14a19a1dd6a0" />


  - Validated that `projectLeader` configurations propagated properly into the `nuclio-dashboard`:
  ```
  kubectl -n mlrun logs nuclio-dashboard-b98b66895-wdr4v | grep -i projectsleader
25.12.04 12:40:41.298 (I)                 dashboard Starting dashboard {"name": "kube", "noPull": false, "offline": false,
....
....
,"projectsLeader":{"kind":"mlrun","apiAddress":"http://mlrun-api-chief:8080/api","synchronizationInterval":"1m"}
  
  ```
