### PR TITLE
[CI] Add read permissions for contents in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
       - "[0-9]+.[0-9]+.x"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   helm-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Added explicit permissions to the GitHub Actions workflow (ci.yaml) by setting contents: read at the top-level of the workflow file.

## Changes Made

Added a permissions block to .github/workflows/ci.yaml.
Set contents permission to read for the workflow.


## Related Issues
- CEML-577