### PR TITLE
[CI] Remove development branch from release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - development
-      - "[0-9]+.[0-9]+.x"
+      - "[0-9]*.[0-9]*.x"
   workflow_dispatch:
 
 jobs:
@@ -17,6 +16,13 @@ jobs:
       contents: write
 
     steps:
+      - name: Validate release branch
+        run: |
+          if ! [[ "${GITHUB_REF_NAME}" =~ ^[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "Refusing to release from non-version branch: ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We need to remove the development branch from the release job as we need to release version only from the dedicated branch of the version.

for example release version for 0.10.x only from branch  0.10.x.

with the current configuration we may release version that includes commits for 0.11.x in 1.10.x releases