### PR TITLE
[Values] Add 1.11.0-rc28 mlrun version to ce values file

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.12.0-rc1
+version: 0.11.0-rc3
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -223,7 +223,7 @@ jupyterNotebook:
     #      - chart-example.local
   image:
     repository: quay.io/mlrun/jupyter
-    tag: 1.10.0
+    tag: 1.11.0-rc28
     pullPolicy: IfNotPresent
     pullSecrets: []
   busybox:

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -98,11 +98,15 @@ mlrun:
   v3io:
     enabled: false
   api:
+    image:
+      tag: 1.11.0-rc28
     ingress:
       enabled: false
       annotations: {}
     sidecars:
       logCollector:
+        image:
+          tag: 1.11.0-rc28
         enabled: true
     fullnameOverride: mlrun-api
     functionSpecServiceAccountDefault: ~
@@ -149,6 +153,8 @@ mlrun:
       # - name: alerts
 
   ui:
+    image:
+      tag: 1.11.0-rc28
     fullnameOverride: mlrun-ui
     ingress:
       enabled: false


### PR DESCRIPTION
This fix resolves https://iguazio.atlassian.net/browse/CEML-633.
By setting mlrun components image tag version to `1.11.x` latest RC when installing chart version `0.11.x`