### PR TITLE
Revert "bump chart to 0.12.0-rc1 (#244)"

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.12.0-rc1
+version: 0.10.1-rc4
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png


### PR DESCRIPTION
This reverts commit eb511a3c9c05ab0b8e076ea7524e1270eb9d212c.