### PR TITLE
[Kafka] Fix NetworkPolicy blocking Kubernetes API server access

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc4
+version: 0.11.0-rc5
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/kafka/kafka-network-policy.yaml
+++ b/charts/mlrun-ce/templates/kafka/kafka-network-policy.yaml
@@ -54,5 +54,13 @@ spec:
   # Allow egress within same namespace
   - to:
     - podSelector: {}
+  
+  # Allow egress to Kubernetes API server (required for controllers, operators, etc.)
+  # This allows traffic to the API server on standard ports
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
 {{- end }}
 


### PR DESCRIPTION
Add egress rules for API server ports (443, 6443)
to allow-kafka-access NetworkPolicy.
Without this, controllers fail on clusters with enforced NetworkPolicies (Calico, Cilium).