### PR TITLE
[Kafka]: Add configuration support

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc6
+version: 0.11.0-rc7
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/kafka/kafka-cluster.yaml
+++ b/charts/mlrun-ce/templates/kafka/kafka-cluster.yaml
@@ -20,6 +20,10 @@ spec:
         port: {{ .port }}
         type: {{ .type }}
         tls: {{ .tls }}
+        {{- if .configuration }}
+        configuration:
+          {{- toYaml .configuration | nindent 10 }}
+        {{- end }}
     {{- end }}
     config:
       {{- toYaml .Values.kafka.config | nindent 6 }}

--- a/charts/mlrun-ce/templates/kafka/kafka-network-policy.yaml
+++ b/charts/mlrun-ce/templates/kafka/kafka-network-policy.yaml
@@ -1,13 +1,14 @@
 {{- if .Values.kafka.rbac.enabled -}}
-{{- $operatorNamespace := .Values.kafka.rbac.operatorNamespace | default .Release.Namespace -}}
 {{- $kafkaName := .Values.kafka.name | default "kafka-stream" -}}
 {{- $currentNamespace := .Release.Namespace -}}
 ---
-# NetworkPolicy: Allow egress from this namespace to Kafka namespace
+# NetworkPolicy: Kafka Isolation
+# Purpose: Ensure pods in this namespace can ONLY connect to Kafka in their OWN
+#          namespace, preventing cross-tenant Kafka access in multi-namespace deployments.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-kafka-access
+  name: kafka-isolation
   namespace: {{ $currentNamespace }}
   labels:
     app.kubernetes.io/name: mlrun-ce
@@ -21,11 +22,13 @@ spec:
   - Egress
   
   egress:
-  # Allow egress to Kafka namespace
+  # =============================================================================
+  # Kafka ports (9092-9094): ONLY allowed to Kafka in the SAME namespace
+  # =============================================================================
   - to:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: {{ $operatorNamespace }}
+          kubernetes.io/metadata.name: {{ $currentNamespace }}
       podSelector:
         matchLabels:
           strimzi.io/cluster: {{ $kafkaName }}
@@ -33,34 +36,36 @@ spec:
     - protocol: TCP
       port: 9092  # client listener
     - protocol: TCP
-      port: 9093  # controller listener
+      port: 9093  # controller listener  
     - protocol: TCP
-      port: 9094  # internal listener
+      port: 9094  # external listener
+
+  # =============================================================================
+  # All other traffic: ALLOWED (no restrictions)
+  # =============================================================================
+  # Allow all egress on non-Kafka ports. This ensures that services like:
+  # - Docker registries (Kaniko builds)
+  # - Kubernetes API server
+  # - DNS
+  # - External APIs
+  # ...continue to work without needing explicit whitelist rules.
   
-  # Allow DNS resolution (required for service discovery)
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: kube-dns
-    ports:
-    - protocol: UDP
-      port: 53
-    - protocol: TCP
-      port: 53
-  
-  # Allow egress within same namespace
-  - to:
-    - podSelector: {}
-  
-  # Allow egress to Kubernetes API server (required for controllers, operators, etc.)
-  # This allows traffic to the API server on standard ports
+  # Allow all TCP traffic on ports below Kafka range
   - ports:
     - protocol: TCP
-      port: 443
+      port: 1
+      endPort: 9091
+  
+  # Allow all TCP traffic on ports above Kafka range
+  - ports:
     - protocol: TCP
-      port: 6443
-{{- end }}
+      port: 9095
+      endPort: 65535
+  
+  # Allow all UDP traffic (DNS, etc.)
+  - ports:
+    - protocol: UDP
+      port: 1
+      endPort: 65535
 
+{{- end }}


### PR DESCRIPTION
__Changes__

1. kafka-cluster.yaml - 
Add configuration block support
Added rendering of the configuration block for Kafka listeners, 
enabling nodePort and advertisedHost settings via Helm values.

2. kafka-network-policy.yaml - Targeted Kafka isolation
- Before: 
Default-deny egress policy requiring whitelist for every service (DNS, API server, registry, etc.)
- After: 
Targeted isolation that:
Restricts Kafka ports (9092-9094) to designated namespace only
Allows all other egress traffic without explicit whitelist
Renamed from allow-kafka-access to kafka-isolation
   
  [JIRA](https://iguazio.atlassian.net/browse/CEML-492)