### PR TITLE
[TimescaleDB] Add NodePort service support for external access

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc7
+version: 0.11.0-rc8
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml
+++ b/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml
@@ -47,6 +47,11 @@ minio:
   mode: standalone
   replicas: 1
 
+timescaledb:
+  service:
+    type: ClusterIP
+    nodePort: ""
+
 spark-operator:
   enabled: false
 

--- a/charts/mlrun-ce/templates/NOTES.txt
+++ b/charts/mlrun-ce/templates/NOTES.txt
@@ -117,5 +117,15 @@ Prometheus UI is available at:
 {{- end }}
 {{- end }}
 
+{{- if .Values.timescaledb.enabled }}
+{{- if eq .Values.timescaledb.service.type "NodePort" }}
+{{- "\n" }}
+TimescaleDB is available at:
+{{ .Values.global.externalHostAddress }}:{{ .Values.timescaledb.service.nodePort }}
+-  username: {{ .Values.timescaledb.auth.username }}
+-  database: {{ .Values.timescaledb.auth.database }}
+{{- end }}
+{{- end }}
+
 Happy MLOPSing!!! :]
 {{- end }}

--- a/charts/mlrun-ce/templates/timescaledb/service.yaml
+++ b/charts/mlrun-ce/templates/timescaledb/service.yaml
@@ -12,6 +12,9 @@ spec:
       port: {{ .Values.timescaledb.service.port }}
       targetPort: postgresql
       protocol: TCP
+{{- if (and (eq .Values.timescaledb.service.type "NodePort") (not (empty .Values.timescaledb.service.nodePort))) }}
+      nodePort: {{ .Values.timescaledb.service.nodePort }}
+{{- end }}
   selector:
     {{- include "mlrun-ce.timescaledb.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -472,8 +472,9 @@ timescaledb:
     tag: "pg17.7-ts2.24.0"
     pullPolicy: IfNotPresent
   service:
-    type: ClusterIP
+    type: NodePort
     port: 5432
+    nodePort: 30110
   auth:
     username: postgres
     password: postgres

--- a/tests/kind-test.sh
+++ b/tests/kind-test.sh
@@ -78,6 +78,9 @@ nodes:
   - containerPort: 30443
     hostPort: 30443
     protocol: TCP
+  - containerPort: 30110
+    hostPort: 30110
+    protocol: TCP
 EOF
 }
 


### PR DESCRIPTION
## Summary
Expose TimescaleDB via NodePort (30110) for external connectivity, consistent with how other CE services (MLRun API, Jupyter, MinIO, etc.) are exposed.

The ticket title references "ingress" but a standard Kubernetes Ingress operates at Layer 7 (HTTP/HTTPS) and cannot route raw TCP/PostgreSQL traffic. NodePort is the appropriate approach for this service, matching the pattern used by other non-HTTP services in CE.

## Changes Made
- **values.yaml**: Set default TimescaleDB service type to `NodePort` with port `30110`
- **templates/timescaledb/service.yaml**: Add conditional `nodePort` field (same pattern as Jupyter)
- **templates/NOTES.txt**: Add TimescaleDB connection info section
- **non_admin_cluster_ip_installation_values.yaml**: Add `ClusterIP` override for non-admin installs
- **tests/kind-test.sh**: Add port 30110 mapping to Kind cluster config

## Testing
- Helm lint passed
- Deployed to vmdev10ig4 cluster: verified NodePort (ce-ns1) and ClusterIP (ce-ns2) modes
- Kind cluster full install: all pods running, TimescaleDB pod verified with SQL queries (PostgreSQL 17.7, TimescaleDB 2.24.0)
- Template rendering verified for default, non-admin ClusterIP, and multi-NS values

## Reference
- Jira: CEML-593