### PR TITLE
[KFP] Connect KFP to use MLRun CE SeaweedFS Solution

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.13
+version: 0.11.0-rc.14
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/pipelines/configmaps/kfp-launcher.yaml
+++ b/charts/mlrun-ce/templates/pipelines/configmaps/kfp-launcher.yaml
@@ -1,11 +1,15 @@
 {{- if .Values.pipelines.enabled -}}
 apiVersion: v1
-data:
-  defaultPipelineRoot: ""
 kind: ConfigMap
 metadata:
-  annotations:
   labels:
     application-crd-id: kubeflow-pipelines
   name: kfp-launcher
+data:
+  # Default pipeline root for artifact storage
+  # NOTE: The "minio://" URI scheme is KFP's internal protocol for S3-compatible storage.
+  # It does NOT refer to the MinIO product - it works with ANY S3-compliant storage including SeaweedFS.
+  # This is the official KFP convention as per: https://www.kubeflow.org/docs/components/pipelines/operator-guides/configure-object-store/
+  # Format: minio://<bucket>/<path>
+  defaultPipelineRoot: "minio://{{ .Values.s3.bucket }}/v2/artifacts"
 {{- end -}}

--- a/charts/mlrun-ce/templates/pipelines/configmaps/pipeline-install-config.yaml
+++ b/charts/mlrun-ce/templates/pipelines/configmaps/pipeline-install-config.yaml
@@ -12,6 +12,7 @@ data:
   cacheImage: {{ .Values.pipelines.images.cacheImage.repository }}:{{ .Values.pipelines.images.cacheImage.tag }}
   cacheNodeRestrictions: "false"
   cronScheduleTimezone: UTC
+  LOG_LEVEL: {{ .Values.pipelines.logLevel | default "INFO" }}
   mysqlHost: mysql
   mysqlPort: "3306"
   defaultPipelineRoot: ""

--- a/charts/mlrun-ce/templates/pipelines/deployments/metadata-envoy-deployment.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/metadata-envoy-deployment.yaml
@@ -40,6 +40,14 @@ spec:
           name: envoy-admin
           protocol: TCP
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          capabilities:
+            drop:
+            - ALL
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst

--- a/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline.yaml
@@ -30,13 +30,18 @@ spec:
     spec:
       containers:
         - env:
+            # Logging configuration
             - name: PUBLISH_LOGS
               value: "true"
             - name: LOG_LEVEL
-              value: "info"
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: LOG_LEVEL
             - name: PIPELINE_LOG_LEVEL
               value: "1"
 
+            # Pipeline configuration
             - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
               valueFrom:
                 configMapKeyRef:
@@ -47,6 +52,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+
+            # Object store configuration (SeaweedFS S3 gateway)
             - name: OBJECTSTORECONFIG_ACCESSKEY
               valueFrom:
                 secretKeyRef:
@@ -74,6 +81,7 @@ spec:
                 configMapKeyRef:
                   name: pipeline-install-config
                   key: bucketName
+            # Database configuration
             - name: DBCONFIG_CONMAXLIFETIME
               valueFrom:
                 configMapKeyRef:
@@ -106,6 +114,8 @@ spec:
                 configMapKeyRef:
                   name: pipeline-install-config
                   key: mysqlPort
+
+            # Driver and launcher images for V2 pipelines
             - name: V2_DRIVER_IMAGE
               value: "{{ .Values.pipelines.images.driver.repository }}:{{ .Values.pipelines.images.driver.tag }}"
             - name: V2_LAUNCHER_IMAGE

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -404,6 +404,8 @@ spark-operator:
 pipelines:
   enabled: true
   name: pipelines
+  # Log level for KFP api-server (DEBUG, INFO, WARNING, ERROR)
+  logLevel: INFO
   ui:
     enabled: false
   service:


### PR DESCRIPTION
Configure Kubeflow Pipelines to use SeaweedFS S3 gateway for artifact storage, 
with KFP 2.x compatibility updates and security hardening.

[CEML-622](https://iguazio.atlassian.net/browse/CEML-622)

[CEML-622]: https://iguazio.atlassian.net/browse/CEML-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ