### PR TITLE
[KFP] Upgrade KFP to version 2.15.0

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.15
+version: 0.11.0-rc.16
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/README.md
+++ b/charts/mlrun-ce/README.md
@@ -284,4 +284,4 @@ This table shows the versions of the main components in the MLRun CE chart:
 
 | MLRun CE   | MLRun  | Nuclio | Jupyter | MPI Operator | SeaweedFS | Spark Operator | Pipelines | Kube-Prometheus-Stack |
 |------------|--------|--------|---------|--------------|-----------|----------------|-----------|-----------------------|
-| **0.11.0** | 1.11.0 | 1.15.9 | 4.5.0   | 0.2.3        | 4.0.407   | 2.1.0          | 2.14.3    | 72.1.1                |
+| **0.11.0** | 1.11.0 | 1.15.9 | 4.5.0   | 0.2.3        | 4.0.407   | 2.1.0          | 2.15.0    | 72.1.1                |

--- a/charts/mlrun-ce/templates/pipelines/configmaps/metadata-envoy-configmap.yaml
+++ b/charts/mlrun-ce/templates/pipelines/configmaps/metadata-envoy-configmap.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.pipelines.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metadata-envoy-configmap
+  labels:
+    application-crd-id: kubeflow-pipelines
+    component: metadata-envoy
+data:
+  envoy-config.yaml: |-
+    admin:
+      access_log:
+        name: admin_access
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          path: /tmp/admin_access.log
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+    static_resources:
+      listeners:
+        - name: listener_0
+          address:
+            socket_address: { address: 0.0.0.0, port_value: 9090 }
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    codec_type: auto
+                    stat_prefix: ingress_http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                        - name: local_service
+                          domains: [ "*" ]
+                          routes:
+                            - match: { prefix: "/" }
+                              route:
+                                cluster: metadata-cluster
+                                max_stream_duration:
+                                  grpc_timeout_header_max: '0s'
+                          typed_per_filter_config:
+                            envoy.filters.http.cors:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                              allow_origin_string_match:
+                                - safe_regex:
+                                    regex: ".*"
+                              allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                              allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                              max_age: "1728000"
+                              expose_headers: custom-header-1,grpc-status,grpc-message
+                    http_filters:
+                      - name: envoy.filters.http.grpc_web
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                      - name: envoy.filters.http.cors
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      clusters:
+        - name: metadata-cluster
+          connect_timeout: 30.0s
+          type: logical_dns
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: { }
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: metadata-cluster
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: metadata-grpc-service
+                          port_value: 8080
+{{- end -}}

--- a/charts/mlrun-ce/templates/pipelines/deployments/metadata-envoy-deployment.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/metadata-envoy-deployment.yaml
@@ -32,6 +32,7 @@ spec:
       - image: {{ .Values.pipelines.images.metadataEnvoy.repository }}:{{ .Values.pipelines.images.metadataEnvoy.tag }}
         imagePullPolicy: IfNotPresent
         name: container
+        args: ["/etc/envoy/envoy-config.yaml"]
         ports:
         - containerPort: 9090
           name: md-envoy
@@ -48,8 +49,16 @@ spec:
           capabilities:
             drop:
             - ALL
+        volumeMounts:
+        - name: envoy-config
+          mountPath: /etc/envoy
+          readOnly: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: envoy-config
+        configMap:
+          name: metadata-envoy-configmap
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/charts/mlrun-ce/templates/pipelines/deployments/metadata-writer.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/metadata-writer.yaml
@@ -28,8 +28,11 @@ spec:
     spec:
       containers:
       - env:
-        - name: METADATA_GRPC_SERVICE_SERVICE_HOST
-          value: metadata-grpc
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: NAMESPACE_TO_WATCH
           valueFrom:
             fieldRef:

--- a/charts/mlrun-ce/templates/pipelines/services/metadata-grpc-service.yaml
+++ b/charts/mlrun-ce/templates/pipelines/services/metadata-grpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: metadata
     application-crd-id: kubeflow-pipelines
-  name: metadata-grpc
+  name: metadata-grpc-service
 spec:
   ports:
   - name: grpc-api

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -441,10 +441,10 @@ pipelines:
   images:
     driver:
       repository: ghcr.io/kubeflow/kfp-driver
-      tag: 2.14.3
+      tag: 2.15.0
     launcher:
       repository: ghcr.io/kubeflow/kfp-launcher
-      tag: 2.14.3
+      tag: 2.15.0
     argoexec:
       repository: gcr.io/iguazio/argoexec
       tag: v3.4.17-license-compliance
@@ -453,32 +453,32 @@ pipelines:
       tag: v3.4.17-license-compliance
     apiServer:
       repository: ghcr.io/kubeflow/kfp-api-server
-      tag: 2.14.3
+      tag: 2.15.0
     persistenceagent:
       repository: ghcr.io/kubeflow/kfp-persistence-agent
-      tag: 2.14.3
+      tag: 2.15.0
     scheduledworkflow:
       repository: ghcr.io/kubeflow/kfp-scheduled-workflow-controller
-      tag: 2.14.3
+      tag: 2.15.0
     ui:
       repository: ghcr.io/kubeflow/kfp-frontend
-      tag: 2.14.3
+      tag: 2.15.0
     viewerCrdController:
       repository: ghcr.io/kubeflow/kfp-viewer-crd-controller
-      tag: 2.14.3
+      tag: 2.15.0
     visualizationServer:
       repository: ghcr.io/kubeflow/kfp-visualization-server
-      tag: 2.14.3
+      tag: 2.15.0
     metadata:
       container:
         repository: gcr.io/tfx-oss-public/ml_metadata_store_server
         tag: 1.16.0
     metadataEnvoy:
       repository: ghcr.io/kubeflow/kfp-metadata-envoy
-      tag: 2.14.3
+      tag: 2.15.0
     metadataWriter:
       repository: ghcr.io/kubeflow/kfp-metadata-writer
-      tag: 2.14.3
+      tag: 2.15.0
     mysql:
       # MySQL 8.0.26 because >= 8.0.27 has deprecated the default_authentication_plugin option
       # which is required by MLMD workloads (metadata-grpc-deployment and metadata-writer).


### PR DESCRIPTION
**What Changed in KFP 2.15.0**

**Before (2.14.3):** The Envoy proxy configuration was baked into the container image. The container had a default config file at a known location, and no external configuration was needed.

**After (2.15.0):** Kubeflow externalized the Envoy configuration to a ConfigMap. The container now expects:
1. A command-line argument pointing to the config file: args: ["/etc/envoy/envoy-config.yaml"]
2. The config file to be mounted from a ConfigMap at /etc/envoy/