### PR TITLE
[MLRun] Update storage auto-mount configuration for SeaweedFS S3-compatible storage

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.16
+version: 0.11.0-rc.17
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/config/jupyter-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/jupyter-env-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   # S3 credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ENDPOINT_URL_S3)
   # are loaded from the 's3-credentials' Secret
-  MLRUN_STORAGE__AUTO_MOUNT_TYPE: {{ default "" .Values.mlrun.storageAutoMountType }}
+  MLRUN_STORAGE__AUTO_MOUNT_TYPE: {{ .Values.mlrun.storageAutoMountType | default "s3" }}
   S3_NON_ANONYMOUS: {{ .Values.global.infrastructure.aws.s3NonAnonymous  | toString | title | quote | default "\"True\"" }}
   MLRUN_CE__MODE: {{ .Values.jupyterNotebook.ce.mode | default "full" }}
   MLRUN_CE__VERSION: {{ .Chart.Version }}

--- a/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mlrun-common-env
 data:
   S3_NON_ANONYMOUS: {{ .Values.global.infrastructure.aws.s3NonAnonymous | toString | title | quote | default "\"True\"" }}
-  MLRUN_STORAGE__AUTO_MOUNT_TYPE: s3
+  MLRUN_STORAGE__AUTO_MOUNT_TYPE: {{ .Values.mlrun.storageAutoMountType | default "s3" }}
   MLRUN_STORAGE__AUTO_MOUNT_PARAMS: {{ include "mlrun.storage.auto.mount.params" . }}
   MLRUN_HTTPDB__PROJECTS__LEADER: mlrun
   MLRUN_HTTPDB__PROJECTS__FOLLOWERS: nuclio

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -93,6 +93,9 @@ mlrun:
       cpu: "25m"
       memory: "1Mi"
   storage: filesystem
+  # Storage auto-mount configuration for SeaweedFS S3-compatible storage
+  # This allows MLRun SDK to automatically mount storage without user-provided params
+  storageAutoMountType: s3
   storageAutoMountParams: ~
   secrets:
     s3:


### PR DESCRIPTION
- Add explicit storageAutoMountType configuration for SeaweedFS S3-compatible storage
- Fix inconsistent storage auto-mount configuration between MLRun API and Jupyter environments
- Enable users to use MLRun SDK commands with SeaweedFS without manually providing S3 credentials