### PR TITLE
[TimescaleDB] Allow setting securityContext on statefulset

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.18
+version: 0.11.0-rc.19
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/timescaledb/statefulset.yaml
+++ b/charts/mlrun-ce/templates/timescaledb/statefulset.yaml
@@ -24,6 +24,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.timescaledb.securityContext }}
+      securityContext:
+        {{- toYaml .Values.timescaledb.securityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: timescaledb
           image: "{{ .Values.timescaledb.image.repository }}:{{ .Values.timescaledb.image.tag }}"

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -579,6 +579,11 @@ timescaledb:
       cpu: "1"
   nodeSelector: {}
   tolerations: []
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    fsGroupChangePolicy: OnRootMismatch
 
 strimzi-kafka-operator:
   enabled: true


### PR DESCRIPTION
## Summary
Add configurable pod-level securityContext to TimescaleDB statefulset to fix Azure volume ownership issues where PVC mounts as root-owned but the container runs as non-root.

## Changes Made
- Add conditional securityContext rendering to statefulset template (follows KFP MySQL pattern)
- Add default securityContext values: runAsUser/runAsGroup/fsGroup 1000, fsGroupChangePolicy OnRootMismatch
- Bump chart version to 0.11.0-rc.17

## Testing
- `helm template` verified with default values, user overrides, and null/disabled securityContext
- Multi-namespace installation modes verified (admin, non-admin, non-admin ClusterIP)

## Reference
- Jira: CEML-660

## Breaking Changes
No — defaults preserve current runtime behavior (UID 1000)