### PR TITLE
[MLRun] Fix UI assigned ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ charts/mlrun-ce/charts/*
 .DS_Store
 **/.DS_Store
 *.DS_Store
+**/__pycache__

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+## Overview
+
+This is a Helm umbrella chart repository for **MLRun Community Edition (CE)** — an open-source MLOps stack. The main chart lives at `charts/mlrun-ce/` and bundles: Nuclio, MLRun, Jupyter, MPI Operator, SeaweedFS (S3-compatible storage), Spark Operator, Kubeflow Pipelines, Prometheus stack, TimescaleDB, and Strimzi Kafka Operator.
+
+## Commands
+
+```bash
+# Lint the helm chart (requires helm and chart-testing `ct` installed)
+make helm-lint
+
+# Update sub-chart dependencies (run before lint or packaging)
+make helm-update-dependencies
+
+# Add all required helm repos from requirements.yaml
+make helm-repo-add
+
+# Package the chart as a tarball
+make package
+
+# Run full local end-to-end test on a Kind cluster (requires docker, kind, kubectl, helm)
+./tests/kind-test.sh full          # Create Kind cluster + install chart
+./tests/kind-test.sh create        # Create cluster only
+./tests/kind-test.sh install       # Install chart (assumes cluster exists)
+./tests/kind-test.sh verify        # Verify installation
+./tests/kind-test.sh delete        # Delete Kind cluster
+CLEANUP_ON_EXIT=true ./tests/kind-test.sh  # Auto-cleanup after test
+```
+
+## Architecture
+
+### Chart Structure
+
+`charts/mlrun-ce/` is an **umbrella chart** that:
+1. Declares sub-chart dependencies in `requirements.yaml` (pulled from external Helm repos)
+2. Provides additional Kubernetes resources via `templates/` that the sub-charts don't include
+3. Wires all components together through shared `values.yaml`
+
+### Template Organization (`charts/mlrun-ce/templates/`)
+
+- `config/` — ConfigMaps and Secrets shared across components: MLRun env config, Jupyter env config, S3 credentials secret, Pipelines config, Spark config, Grafana dashboards
+- `seaweedfs/` — SeaweedFS-specific resources: S3 IAM config secret, bucket init job, admin UI NodePort service, ingress
+- `kafka/` — Kafka Strimzi custom resources: KafkaNodePool, Kafka cluster CR, bootstrap alias Service, RBAC, NetworkPolicy
+- `timescaledb/` — TimescaleDB Deployment, Service, PVC
+- `jupyter-notebook/` — Jupyter Deployment and supporting resources
+- `pipelines/` — Kubeflow Pipelines resources
+- `persistency/` — PVC definitions
+- `aws/` — AWS-specific resources
+
+### Key Design Patterns
+
+**S3 credentials propagation**: The top-level `s3.accessKey`/`s3.secretKey`/`s3.bucket` values flow into a `s3-credentials` Secret (created by `templates/config/s3-credentials-secret.yaml`), which is then mounted via `envFrom` in MLRun API and Jupyter pods. SeaweedFS uses the same credentials via the `seaweedfs-s3-config` Secret.
+
+**Global registry anchor**: `global.registry: &userRegistry` in `values.yaml` uses YAML anchors to multiplex the same docker registry config to both `nuclio.global.registry` and `mlrun.global.registry`.
+
+**SeaweedFS as S3 backend**: SeaweedFS replaced MinIO. The helpers in `_helpers.tpl` (`mlrun-ce.s3.*`) generate the SeaweedFS service URL. Legacy `mlrun-ce.minio.*` helpers are kept as aliases pointing to the SeaweedFS helpers.
+
+**Component enable/disable**: Most components can be disabled via `<component>.enabled: false`. The Kafka setup requires the Strimzi operator (deployed as a sub-chart via `strimzi-kafka-operator`) and custom Strimzi CRs in `templates/kafka/`.
+
+### Values Files
+
+- `charts/mlrun-ce/admin_installation_values.yaml` — admin install
+- `charts/mlrun-ce/non_admin_installation_values.yaml` — non-admin install
+- `charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml` — non-admin with ClusterIP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.17
+version: 0.11.0-rc.18
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/requirements.lock
+++ b/charts/mlrun-ce/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.21.9
 - name: mlrun
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.11.12
+  version: 0.11.18
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.6.0
@@ -20,5 +20,5 @@ dependencies:
 - name: strimzi-kafka-operator
   repository: https://strimzi.io/charts/
   version: 0.48.0
-digest: sha256:f87ec580f73178cfc897d57e26f5d7b049900f1b7ef75bfe198ca327eb2ed06d
-generated: "2026-02-12T23:52:46.490844+02:00"
+digest: sha256:f7f2ab0eaec5fb3097c09946f6de510a602293fd7f9c59c40539991b5449a6d1
+generated: "2026-03-08T12:42:39.145588+02:00"

--- a/charts/mlrun-ce/requirements.yaml
+++ b/charts/mlrun-ce/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
     version: "0.21.9"
     repository: "https://nuclio.github.io/nuclio/charts"
   - name: mlrun
-    version: "0.11.12"
+    version: "0.11.18"
     repository: "https://v3io.github.io/helm-charts/stable"
     condition: mlrun.enabled
   - name: mpi-operator

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -181,8 +181,6 @@ mlrun:
     service:
       type: NodePort
       nodePort: 30060
-      port: 80
-      targetPort: 8090
   db:
     name: db
     fullnameOverride: mlrun-db

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -181,6 +181,8 @@ mlrun:
     service:
       type: NodePort
       nodePort: 30060
+      port: 80
+      targetPort: 8090
   db:
     name: db
     fullnameOverride: mlrun-db


### PR DESCRIPTION
* Bumped mlrun chart version to introduce mlrun ui containerPort fix
* Updated the chart version in `charts/mlrun-ce/Chart.yaml` from `0.11.0-rc.17` to `0.11.0-rc.18` to reflect recent changes.

In addition, this PR introduces documentation for agentic flows


⏺ Changes between mlrun chart 0.11.12 and 0.11.18:                                                                                         
                                                   
  - Fix UI container port — hardcode containerPort to 8090 (https://github.com/v3io/helm-charts/pull/1136)                                                                         
  - Support ReadWriteMany access mode when worker replicas > 0 (https://github.com/v3io/helm-charts/pull/1133)                                                                     
  - Increase deployment max surge (https://github.com/v3io/helm-charts/pull/1124)
  - Upgrade MySQL to 8.4 (https://github.com/v3io/helm-charts/pull/1120)
