### PR TITLE
Fix egress to allow connect to external servers on port 9092

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.18
+version: 0.11.0-rc.19
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.12.0-rc1
+version: 0.11.0-rc3
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.19
+version: 0.11.0-rc.20
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml
+++ b/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml
@@ -83,6 +83,8 @@ strimzi-kafka-operator:
 kafka:
   rbac:
     operatorNamespace: controller
+  egress:
+    enabled: true
 
 kube-prometheus-stack:
   enabled: false

--- a/charts/mlrun-ce/non_admin_installation_values.yaml
+++ b/charts/mlrun-ce/non_admin_installation_values.yaml
@@ -77,6 +77,8 @@ strimzi-kafka-operator:
 kafka:
   rbac:
     operatorNamespace: controller
+  egress:
+    enabled: true
 
 kube-prometheus-stack:
   enabled: false

--- a/charts/mlrun-ce/templates/kafka/kafka-network-policy.yaml
+++ b/charts/mlrun-ce/templates/kafka/kafka-network-policy.yaml
@@ -15,12 +15,12 @@ metadata:
     app.kubernetes.io/component: kafka-rbac
     app.kubernetes.io/managed-by: {{ .Release.Name }}
 spec:
-  # Apply to all pods in this namespace
+  # Apply to Kafka pods in this namespace
   podSelector:
     matchLabels:
-      strimzi.io/cluster: { { $kafkaName } }
+      strimzi.io/cluster: {{ $kafkaName }}
       strimzi.io/kind: Kafka
-      strimzi.io/name: { { $kafkaName } }-kafka
+      strimzi.io/name: {{ $kafkaName }}-kafka
   
   policyTypes:
   - Egress

--- a/charts/mlrun-ce/templates/kafka/kafka-network-policy.yaml
+++ b/charts/mlrun-ce/templates/kafka/kafka-network-policy.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: {{ $currentNamespace }}
   labels:
     app.kubernetes.io/name: mlrun-ce
-    app.kubernetes.io/component: kafka-rbac
+    app.kubernetes.io/component: kafka-network-policy
     app.kubernetes.io/managed-by: {{ .Release.Name }}
 spec:
   # Apply to Kafka pods in this namespace

--- a/charts/mlrun-ce/templates/kafka/kafka-network-policy.yaml
+++ b/charts/mlrun-ce/templates/kafka/kafka-network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kafka.rbac.enabled -}}
+{{- if .Values.kafka.egress.enabled -}}
 {{- $kafkaName := .Values.kafka.name | default "kafka-stream" -}}
 {{- $currentNamespace := .Release.Namespace -}}
 ---
@@ -16,7 +16,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Name }}
 spec:
   # Apply to all pods in this namespace
-  podSelector: {}
+  podSelector:
+    matchLabels:
+      strimzi.io/cluster: { { $kafkaName } }
+      strimzi.io/kind: Kafka
+      strimzi.io/name: { { $kafkaName } }-kafka
   
   policyTypes:
   - Egress

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -650,7 +650,8 @@ kafka:
     # Empty means "use the release namespace"
     # Example: "controller" if that's where you installed the operator
     operatorNamespace: ""
-
+  egress:
+    enabled: false
 # Spark configuration for multi-NS deployments
 # Controls CE-level spark resources (mlrun-spark-config ConfigMap)
 # In single-NS mode, both spark.enabled and spark-operator.enabled are true

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -641,7 +641,7 @@ kafka:
 
   # Kafka RBAC for user namespaces
   # Enable this when installing in user namespaces (mlrun, mlrun1, etc.)
-  # When enabled, creates: ServiceAccount "kafka-client" + Role/RoleBinding + NetworkPolicy
+  # When enabled, creates: ServiceAccount "kafka-client" + Role/RoleBinding
   rbac:
     # Enable RBAC for this namespace to access Kafka
     enabled: true
@@ -650,6 +650,8 @@ kafka:
     # Empty means "use the release namespace"
     # Example: "controller" if that's where you installed the operator
     operatorNamespace: ""
+
+  # NetworkPolicy for Kafka isolation in multi-NS deployments
   egress:
     enabled: false
 # Spark configuration for multi-NS deployments

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -98,11 +98,15 @@ mlrun:
   v3io:
     enabled: false
   api:
+    image:
+      tag: 1.11.0-rc28
     ingress:
       enabled: false
       annotations: {}
     sidecars:
       logCollector:
+        image:
+          tag: 1.11.0-rc28
         enabled: true
     fullnameOverride: mlrun-api
     functionSpecServiceAccountDefault: ~
@@ -149,6 +153,8 @@ mlrun:
       # - name: alerts
 
   ui:
+    image:
+      tag: 1.11.0-rc28
     fullnameOverride: mlrun-ui
     ingress:
       enabled: false


### PR DESCRIPTION
Fix https://iguazio.atlassian.net/browse/CEML-666

The current configuration limits connections to all external components on port 9092, we should limit it only for Kafka pods and only for multi-NS installations.
This PR includes - 
1. Disable egress by default for single NS installation
2. Enable  egress for multi NS installation
3. Add `podSelector` to disable connection to other Kafka components in other NS and not all components 