### PR TITLE
Disable storing KFP pods logs by default

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.12.0-rc1
+version: 0.11.0-rc3
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.20
+version: 0.11.0-rc.22
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/pipelines/configmaps/workflow-controller-configmap.yaml
+++ b/charts/mlrun-ce/templates/pipelines/configmaps/workflow-controller-configmap.yaml
@@ -7,7 +7,7 @@ data:
     port: 9090
     ignoreErrors: false
   artifactRepository: |
-    archiveLogs: false
+    archiveLogs: {{ .Values.pipelines.archiveLogs }}
     s3:
       endpoint: "{{ include "mlrun-ce.s3.service.host" . }}:{{ include "mlrun-ce.s3.service.port" . }}"
       bucket: "{{ include "mlrun-ce.s3.bucket" . }}"

--- a/charts/mlrun-ce/templates/pipelines/configmaps/workflow-controller-configmap.yaml
+++ b/charts/mlrun-ce/templates/pipelines/configmaps/workflow-controller-configmap.yaml
@@ -7,7 +7,7 @@ data:
     port: 9090
     ignoreErrors: false
   artifactRepository: |
-    archiveLogs: true
+    archiveLogs: false
     s3:
       endpoint: "{{ include "mlrun-ce.s3.service.host" . }}:{{ include "mlrun-ce.s3.service.port" . }}"
       bucket: "{{ include "mlrun-ce.s3.bucket" . }}"

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -405,6 +405,7 @@ spark-operator:
       name: sparkapp
 
 pipelines:
+  archiveLogs: false
   enabled: true
   name: pipelines
   # Log level for KFP api-server (DEBUG, INFO, WARNING, ERROR)

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -98,11 +98,15 @@ mlrun:
   v3io:
     enabled: false
   api:
+    image:
+      tag: 1.11.0-rc28
     ingress:
       enabled: false
       annotations: {}
     sidecars:
       logCollector:
+        image:
+          tag: 1.11.0-rc28
         enabled: true
     fullnameOverride: mlrun-api
     functionSpecServiceAccountDefault: ~
@@ -149,6 +153,8 @@ mlrun:
       # - name: alerts
 
   ui:
+    image:
+      tag: 1.11.0-rc28
     fullnameOverride: mlrun-ui
     ingress:
       enabled: false


### PR DESCRIPTION
This PR fix https://iguazio.atlassian.net/browse/CEML-675
And includes the following - 
Change the default value for `archiveLogs` to `false` and, by that, disable storing KFP pods' logs by default when running a workflow.