### PR TITLE
[SeaweedFS] Change storageAutoMountType to secret_env in Jupyter and MLRun

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.20
+version: 0.11.0-rc.21
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/_helpers.tpl
+++ b/charts/mlrun-ce/templates/_helpers.tpl
@@ -191,7 +191,7 @@ Uses SeaweedFS as the storage backend
   {{- if .Values.mlrun.storageAutoMountParams -}}
     {{ .Values.mlrun.storageAutoMountParams }}
   {{- else if not .Values.global.infrastructure.aws.s3NonAnonymous -}}
-    "secret_name=s3-credentials,endpoint_url={{ include "mlrun-ce.s3.service.url" . }}"
+    "secret_name=s3-credentials"
   {{- else -}}
     "non_anonymous=True"
   {{- end -}}

--- a/charts/mlrun-ce/templates/config/jupyter-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/jupyter-env-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   # S3 credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ENDPOINT_URL_S3)
   # are loaded from the 's3-credentials' Secret
-  MLRUN_STORAGE__AUTO_MOUNT_TYPE: {{ .Values.mlrun.storageAutoMountType | default "s3" }}
+  MLRUN_STORAGE__AUTO_MOUNT_TYPE: {{ .Values.mlrun.storageAutoMountType | default "secret_env" }}
   S3_NON_ANONYMOUS: {{ .Values.global.infrastructure.aws.s3NonAnonymous  | toString | title | quote | default "\"True\"" }}
   MLRUN_CE__MODE: {{ .Values.jupyterNotebook.ce.mode | default "full" }}
   MLRUN_CE__VERSION: {{ .Chart.Version }}

--- a/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mlrun-common-env
 data:
   S3_NON_ANONYMOUS: {{ .Values.global.infrastructure.aws.s3NonAnonymous | toString | title | quote | default "\"True\"" }}
-  MLRUN_STORAGE__AUTO_MOUNT_TYPE: {{ .Values.mlrun.storageAutoMountType | default "s3" }}
+  MLRUN_STORAGE__AUTO_MOUNT_TYPE: {{ .Values.mlrun.storageAutoMountType | default "secret_env" }}
   MLRUN_STORAGE__AUTO_MOUNT_PARAMS: {{ include "mlrun.storage.auto.mount.params" . }}
   MLRUN_HTTPDB__PROJECTS__LEADER: mlrun
   MLRUN_HTTPDB__PROJECTS__FOLLOWERS: nuclio

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -95,7 +95,7 @@ mlrun:
   storage: filesystem
   # Storage auto-mount configuration for SeaweedFS S3-compatible storage
   # This allows MLRun SDK to automatically mount storage without user-provided params
-  storageAutoMountType: s3
+  storageAutoMountType: secret_env
   storageAutoMountParams: ~
   secrets:
     s3:


### PR DESCRIPTION
`storageAutoMountType` is changed from `s3` to `secret_env` in both Jupyter and MLRun configmap and in the `values.yaml` file.

`endpoint_url` is also removed from the `storageAutoMountParams` since it's specific to s3 automount type.

https://iguazio.atlassian.net/browse/CEML-671 / https://iguazio.atlassian.net/browse/CEML-676