### PR TITLE
Add an init container that's wait to seaweedfs api pod

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.22
+version: 0.11.0-rc.23
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.12.0-rc1
+version: 0.11.0-rc3
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline.yaml
@@ -165,6 +165,31 @@ spec:
               memory: 500Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+      {{- if .Values.seaweedfs.enabled }}
+      initContainers:
+        - name: wait-for-seaweedfs
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until wget -q -S -O /dev/null http://${SEAWEEDFS_HOST}:${SEAWEEDFS_PORT}/ 2>&1 | grep -q "HTTP/"; do
+                echo "Waiting for SeaweedFS S3 to be ready..."
+                sleep 5
+              done
+              echo "SeaweedFS S3 is ready."
+          env:
+            - name: SEAWEEDFS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: objectStoreServiceHost
+            - name: SEAWEEDFS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: objectStoreServicePort
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline.yaml
+++ b/charts/mlrun-ce/templates/pipelines/deployments/ml-pipeline.yaml
@@ -166,14 +166,17 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       {{- if .Values.seaweedfs.enabled }}
+      # Add an init container to wait for the SeaweedFS S3 gateway to be ready before starting the ml-pipeline-api-server
+      # Use /status endpoint to check if the S3 gateway is ready, as it returns 200 OK when ready.
+      # Same as the Liveness and Readiness probes used in the SeaweedFS S3 deployment.
       initContainers:
         - name: wait-for-seaweedfs
-          image: busybox:1.36
+          image: {{ .Values.pipelines.images.apiServer.busybox.repository }}:{{ .Values.pipelines.images.apiServer.busybox.tag }}
           command:
             - sh
             - -c
             - |
-              until wget -q -S -O /dev/null http://${SEAWEEDFS_HOST}:${SEAWEEDFS_PORT}/ 2>&1 | grep -q "HTTP/"; do
+              until wget -q -S -O /dev/null http://${SEAWEEDFS_HOST}:${SEAWEEDFS_PORT}/status 2>&1 | grep -q "HTTP/"; do
                 echo "Waiting for SeaweedFS S3 to be ready..."
                 sleep 5
               done

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -458,6 +458,9 @@ pipelines:
     apiServer:
       repository: ghcr.io/kubeflow/kfp-api-server
       tag: 2.15.0
+      busybox:
+        repository: busybox
+        tag: "1.36"
     persistenceagent:
       repository: ghcr.io/kubeflow/kfp-persistence-agent
       tag: 2.15.0

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -98,11 +98,15 @@ mlrun:
   v3io:
     enabled: false
   api:
+    image:
+      tag: 1.11.0-rc28
     ingress:
       enabled: false
       annotations: {}
     sidecars:
       logCollector:
+        image:
+          tag: 1.11.0-rc28
         enabled: true
     fullnameOverride: mlrun-api
     functionSpecServiceAccountDefault: ~
@@ -149,6 +153,8 @@ mlrun:
       # - name: alerts
 
   ui:
+    image:
+      tag: 1.11.0-rc28
     fullnameOverride: mlrun-ui
     ingress:
       enabled: false


### PR DESCRIPTION
This PR fixes an issue where the KFP API pod fails with `CrashLoopBackOff` while trying to connect to the SeaweedFS API, but this pod is not in running state.
This PR adds an init container to the KFP API that waits to the SeaweedFS API and then init the KFP API