### PR TITLE
[Spark] Disable S3A change detection for SeaweedFS compatibility

### DIFF
--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -43,4 +43,9 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN mkdir /home/spark && chown spark /home/spark
 
+# Disable S3A ETag-based change detection — SeaweedFS does not return ETags
+# in a format that satisfies Hadoop's S3A change detection requirements (CEML-669)
+RUN mkdir -p /opt/spark/conf && \
+    echo "spark.hadoop.fs.s3a.change.detection.mode none" >> /opt/spark/conf/spark-defaults.conf
+
 USER spark


### PR DESCRIPTION
## Summary
- Spark jobs fail with `NoVersionAttributeException: Change detection policy requires ETag` when reading from SeaweedFS
- SeaweedFS does not return ETags in the format expected by Hadoop's S3A change detection policy
- Fix: disable ETag-based change detection by adding `spark.hadoop.fs.s3a.change.detection.mode none` to `spark-defaults.conf` in the CE Spark Docker image

## Test plan
- [ ] Rebuild Spark image (`cd docker/spark && make build`)
- [ ] Push image to registry
- [ ] Deploy CE with updated image
- [ ] Run `test_mlrun_spark_operator_using_set_function` to verify Spark jobs can read from SeaweedFS without ETag errors

Fixes: CEML-669

🤖 Generated with [Claude Code](https://claude.com/claude-code)