### PR TITLE
[SeaweedFS] Upgrade to 4.17 to fix S3A ETag compatibility with Spark

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.29
+version: 0.11.0-rc.30
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/README.md
+++ b/charts/mlrun-ce/README.md
@@ -284,4 +284,4 @@ This table shows the versions of the main components in the MLRun CE chart:
 
 | MLRun CE   | MLRun  | Nuclio | Jupyter | MPI Operator | SeaweedFS | Spark Operator | Pipelines | Kube-Prometheus-Stack |
 |------------|--------|--------|---------|--------------|-----------|----------------|-----------|-----------------------|
-| **0.11.0** | 1.11.0 | 1.15.9 | 4.5.0   | 0.2.3        | 4.0.407   | 2.1.0          | 2.15.0    | 72.1.1                |
+| **0.11.0** | 1.11.0 | 1.15.9 | 4.5.0   | 0.2.3        | 4.17.0    | 2.1.0          | 2.15.0    | 72.1.1                |

--- a/charts/mlrun-ce/requirements.lock
+++ b/charts/mlrun-ce/requirements.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.6.0
 - name: seaweedfs
   repository: https://seaweedfs.github.io/seaweedfs/helm
-  version: 4.0.407
+  version: 4.17.0
 - name: spark-operator
   repository: https://kubeflow.github.io/spark-operator
   version: 2.1.0
@@ -20,5 +20,5 @@ dependencies:
 - name: strimzi-kafka-operator
   repository: https://strimzi.io/charts/
   version: 0.48.0
-digest: sha256:f7f2ab0eaec5fb3097c09946f6de510a602293fd7f9c59c40539991b5449a6d1
-generated: "2026-03-08T12:42:39.145588+02:00"
+digest: sha256:e2b2d1b7531c4829aa25c8ce8d95506642ab59d0cb692a343d2e508a71525374
+generated: "2026-03-31T17:13:31.403112322Z"

--- a/charts/mlrun-ce/requirements.yaml
+++ b/charts/mlrun-ce/requirements.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: "https://v3io.github.io/helm-charts/stable"
   - name: seaweedfs
     repository: "https://seaweedfs.github.io/seaweedfs/helm"
-    version: "4.0.407"
+    version: "4.17.0"
     condition: seaweedfs.enabled
   - name: spark-operator
     repository: "https://kubeflow.github.io/spark-operator"

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -310,6 +310,8 @@ mpi-operator:
 
 seaweedfs:
   enabled: true
+  # Preserve resource names after chart upgrade (4.17 switched from seaweedfs.name to seaweedfs.fullname)
+  fullnameOverride: seaweedfs
   global:
     # Override parent chart's global.registry (which is a map) with empty string
     # to prevent "map[secretName:<nil> url:mustprovide]" in image names

--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -43,9 +43,4 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN mkdir /home/spark && chown spark /home/spark
 
-# Disable S3A ETag-based change detection — SeaweedFS does not return ETags
-# in a format that satisfies Hadoop's S3A change detection requirements (CEML-669)
-RUN mkdir -p /opt/spark/conf && \
-    echo "spark.hadoop.fs.s3a.change.detection.mode none" >> /opt/spark/conf/spark-defaults.conf
-
 USER spark


### PR DESCRIPTION
## Summary

Upgrade SeaweedFS from chart 4.0.407 (v4.07) to 4.17.0 (v4.17) to fix CEML-669 — Spark jobs failing with `Change detection policy requires ETag` when accessing SeaweedFS.

## Root Cause

SeaweedFS 4.07 has a bug where `HeadObject` returns **no ETag after `CopyObject`** ([seaweedfs/seaweedfs#8155](https://github.com/seaweedfs/seaweedfs/issues/8155)). Hadoop's S3A client uses ETag-based change detection, which throws `NoVersionAttributeException` during Spark's rename/commit operations (copy + delete pattern used when writing Parquet output).

The previous fix attempt (PR #279) baked `spark.hadoop.fs.s3a.change.detection.mode none` into the Spark Docker image's `spark-defaults.conf`. This **cannot work** because the spark-operator mounts a ConfigMap volume at `/opt/spark/conf/`, completely shadowing the image's config directory.

## Fix

Upgrade SeaweedFS so it returns proper ETags for all S3 operations:

- **4.09**: CopyObject ETag fix ([seaweedfs/seaweedfs#8156](https://github.com/seaweedfs/seaweedfs/pull/8156), [seaweedfs/seaweedfs#8163](https://github.com/seaweedfs/seaweedfs/pull/8163))
- **4.12**: Multipart upload ETag fix ([seaweedfs/seaweedfs#8238](https://github.com/seaweedfs/seaweedfs/pull/8238))
- **4.17**: Latest stable, includes all ETag fixes

Also adds `fullnameOverride: seaweedfs` to preserve resource names — the new chart switched from `seaweedfs.name` to `seaweedfs.fullname` in templates, which would otherwise prefix all resources with the Helm release name.

## Changes

- `requirements.yaml`: SeaweedFS `4.0.407` → `4.17.0`
- `requirements.lock`: Regenerated
- `values.yaml`: Added `fullnameOverride: seaweedfs`

## Breaking Changes

None. The chart upgrade was verified:
- `values.yaml` changes are additive only (new optional fields: iceberg, bucket TTL/versioning, volume ingress)
- Worker config field renames (`capabilities` → `jobType`) don't affect CE (we don't set those)
- `fullnameOverride: seaweedfs` ensures all resource names remain unchanged

## Test Plan

- [ ] Helm lint passes
- [ ] Deploy on test cluster and verify SeaweedFS pods start correctly
- [ ] Run Spark job that reads/writes to SeaweedFS via s3a:// — no ETag errors
- [ ] Verify SeaweedFS resource names unchanged (`kubectl get all -l app.kubernetes.io/name=seaweedfs`)
- [ ] Run naipi `test_mlrun_spark_operator_using_set_function_not_set_` test

## Reference

- Jira: CEML-669
- SeaweedFS ETag bug: [seaweedfs/seaweedfs#8155](https://github.com/seaweedfs/seaweedfs/issues/8155)
- Previous (ineffective) fix: #279