### PR TITLE
[Spark] Fix GCS connector compatibility with Spark 3.5.x 

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.30
+version: 0.11.0-rc.31
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/config/mlrun-spark-config.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-spark-config.yaml
@@ -6,5 +6,5 @@ metadata:
 data:
   MLRUN_SPARK_OPERATOR_VERSION: spark-3
   MLRUN_SPARK_APP_IMAGE: gcr.io/iguazio/spark-app
-  MLRUN_SPARK_APP_IMAGE_TAG: 3.5.6-scala2.12-java17-ubuntu
+  MLRUN_SPARK_APP_IMAGE_TAG: 3.5.6-scala2.12-java17-ubuntu-1
 {{- end -}}

--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -29,7 +29,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.11 get-pi
 RUN curl -f -o /opt/spark/jars/hadoop-aws-3.3.4.jar -LO https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar
 RUN curl -f -o /opt/spark/jars/aws-java-sdk-bundle-1.12.262.jar -LO https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar
 RUN curl -f -o /opt/spark/jars/wildfly-openssl-1.0.12.Final.jar -LO https://repo1.maven.org/maven2/org/wildfly/openssl/wildfly-openssl/1.0.12.Final/wildfly-openssl-1.0.12.Final.jar
-RUN curl -f -o /opt/spark/jars/gcs-connector-3.1.10-shaded.jar -LO https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/3.1.10/gcs-connector-3.1.10-shaded.jar
+RUN curl -f -o /opt/spark/jars/gcs-connector-hadoop3-2.2.33-shaded.jar -LO https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.33/gcs-connector-hadoop3-2.2.33-shaded.jar
 RUN curl -f -o /opt/spark/jars/spark-bigquery-with-dependencies_2.12-0.43.1.jar -LO https://repo1.maven.org/maven2/com/google/cloud/spark/spark-bigquery-with-dependencies_2.12/0.43.1/spark-bigquery-with-dependencies_2.12-0.43.1.jar
 RUN curl -f -o /opt/spark/jars/hadoop-azure-3.3.4.jar -LO https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar
 RUN curl -f -o /opt/spark/jars/azure-storage-7.0.1.jar -LO https://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/7.0.1/azure-storage-7.0.1.jar

--- a/docker/spark/Makefile
+++ b/docker/spark/Makefile
@@ -1,5 +1,5 @@
 MLRUN_CE_IMAGE_PLATFORM ?= linux/amd64
-MLRUN_CE_IMAGE_TAG ?= gcr.io/iguazio/spark-app:3.5.6-scala2.12-java17-ubuntu
+MLRUN_CE_IMAGE_TAG ?= gcr.io/iguazio/spark-app:3.5.6-scala2.12-java17-ubuntu-1
 
 .PHONY: build
 build:


### PR DESCRIPTION
## Summary
Downgrade gcs-connector from 3.1.10 to hadoop3-2.2.33, the stable Hadoop 3.x compatible version that works with Spark 3.5.x. The 3.1.10 version caused classpath/compatibility issues.

## Changes Made
- Swap `gcs-connector-3.1.10-shaded.jar` for `gcs-connector-hadoop3-2.2.33-shaded.jar` in Spark Dockerfile
- Bump Spark image tag to `3.5.6-scala2.12-java17-ubuntu-1`


## Testing
- Verified GCS connector jar exists and is valid in the built image
- Verified `GoogleHadoopFileSystem` and `GoogleHadoopFS` classes load successfully in Spark
- Verified GCS FileSystem can be instantiated (no classpath errors)

## Reference
- Jira: CEML-573