### PR TITLE
[FIX] Increase max volume in default installations 

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.11.0-rc.33
+version: 0.11.0-rc.34
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -328,6 +328,9 @@ seaweedfs:
     enabled: false
   volume:
     enabled: false
+    dataDirs:
+      - name: data1
+        maxVolumes: 12
   filer:
     enabled: false
 
@@ -342,6 +345,8 @@ seaweedfs:
   # Reduces from 4 component pods down to 1, cutting CPU/memory footprint significantly.
   allInOne:
     enabled: true
+    extraEnvironmentVars:
+      WEED_MASTER_VOLUME_GROWTH_COPY_1: "1"
     s3:
       enabled: true
       port: 8333

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -322,6 +322,8 @@ seaweedfs:
     # delete other pods during data migration (e.g., multi-node rebalancing).
     # Enabling this creates a ClusterRole, which conflicts in multi-NS deployments.
     createClusterRole: false
+    extraEnvironmentVars:
+      WEED_MASTER_VOLUME_GROWTH_COPY_1: "1"
 
   # Disable individual component pods - allInOne runs everything in a single deployment
   master:
@@ -345,8 +347,6 @@ seaweedfs:
   # Reduces from 4 component pods down to 1, cutting CPU/memory footprint significantly.
   allInOne:
     enabled: true
-    extraEnvironmentVars:
-      WEED_MASTER_VOLUME_GROWTH_COPY_1: "1"
     s3:
       enabled: true
       port: 8333


### PR DESCRIPTION
### 🛠️ Changes Made
1. Increase the amount of max volumes as the all in one uses 8 by default
2. Create one volume for each bucket

---

### ✅ Checklist
- [X] I have tested the changes in this PR
- [X] I confirmed whether my changes require a change in documentation and if so, I created another PR in MLRun for the relevant documentation.
- [X] I confirmed whether my changes require a changes in QA tests, for example: credentials changes, resources naming change and if so, I updated the relevant Jira ticket for QA.
- [X] I increased the Chart version in `charts/mlrun-ce/Chart.yaml`.
- [X] I confirmed that the installation works both on a local Docker Desktop environment and on a real cluster when using the required [prerequisites](https://docs.mlrun.org/en/stable/install-mlrun-ce/kubernetes-install.html#prerequisites).


### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/CEML-696

