### PR TITLE
[FIX] TimescaleDB StatefulSet Helm template by allowing the specification of image pull secrets.  (#290)

### DIFF
--- a/charts/mlrun-ce/templates/timescaledb/statefulset.yaml
+++ b/charts/mlrun-ce/templates/timescaledb/statefulset.yaml
@@ -28,6 +28,10 @@ spec:
       securityContext:
         {{- toYaml .Values.timescaledb.securityContext | nindent 8 }}
       {{- end }}
+      {{- with .Values.timescaledb.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: timescaledb
           image: "{{ .Values.timescaledb.image.repository }}:{{ .Values.timescaledb.image.tag }}"


### PR DESCRIPTION
This pull request introduces a configuration improvement to the TimescaleDB StatefulSet Helm template by allowing the specification of image pull secrets. This change enables users to pull container images from private registries when deploying TimescaleDB.

Configuration enhancement:

* Added support for specifying `imagePullSecrets` in the TimescaleDB StatefulSet template, allowing images to be pulled from private registries. (`charts/mlrun-ce/templates/timescaledb/statefulset.yaml`)ce: Add imagePullSecrets support to statefulset template