### PR TITLE
[CI] CEML-709: Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/demos_notebook_tests.yml
+++ b/.github/workflows/demos_notebook_tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
     - name: Extract private key
       run: echo "${{ secrets.TEST_SYSTEM_MLRUN_PEM }}" > mlrun.pem
     - name: Set permissions on key

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Validate PR title and assign label
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 
@@ -101,7 +101,7 @@ jobs:
 
       - name: Generate release notes with git-cliff
         if: steps.version_check.outputs.is_rc == 'false'
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 #v4
         with:
           config: cliff.toml
           args: >-


### PR DESCRIPTION
## Pull Request: [CI] CEML-709: Pin GitHub Actions to immutable commit SHAs

### Summary

GitHub code scanning [alert #17](https://github.com/mlrun/ce/security/code-scanning/17) flagged that four GitHub Actions steps used mutable version tags (`@v4`, `@v7`, `@v2`). Because tags are Git refs that can be force-pushed, they are not immutable — a compromised upstream repo could silently swap the code that runs in CI. This PR pins every affected `uses:` line to the exact commit SHA the tag currently resolves to, while preserving the tag as a trailing comment for human readability.

### What Changed

- Pinned all four unpinned `uses:` references across three workflow files to their current commit SHAs
- Pattern follows the existing convention already used in the repo (e.g. `azure/setup-helm@<sha> #v4.3.1`)

| File | Action | Old ref | New ref |
|---|---|---|---|
| `release.yml` | `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4` |
| `release.yml` | `orhun/git-cliff-action` | `@v4` | `@f50e11560dce63f7c33227798f90b924471a88b5 #v4` |
| `pr-validation.yml` | `actions/github-script` | `@v7` | `@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7` |
| `demos_notebook_tests.yml` | `actions/checkout` | `@v2` | `@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2` |

Actions already pinned to SHAs (unchanged): `azure/setup-helm`, `helm/chart-releaser-action`, `appleboy/ssh-action`.

### Key Points

- Zero functional change — each SHA resolves to exactly the same commit the mutable tag pointed to
- Closes the GitHub code scanning supply-chain vulnerability alert
- Future version bumps require a deliberate SHA update in a PR, providing an audit trail

### Files Changed

- **Total files:** 3 (0 added, 3 modified, 0 deleted)
- **Main areas affected:**
  - `.github/workflows/`: security hardening of CI action references

### Testing

No logic was changed. Workflows will execute identically — the SHA-pinned actions resolve to the same code as the tags they replace.

---

Closes CEML-709

<details>
<summary>Commit History (for reference)</summary>

This PR includes 1 commit:

- `ff2f7cd` CEML-709: Pin GitHub Actions to immutable commit SHAs

</details>
