### PR TITLE
[Fix] s3-bucket-init job IMDS region crash

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,20 @@ jobs:
           python-version: "3.x"
           check-latest: true
       - name: Set up chart-testing
+        id: chart-testing-setup
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f #v2.8.0
+        with:
+          version: v3.10.1
+        continue-on-error: true
+      - name: Clean partial chart-testing cache
+        # ct.sh creates the cache dir before verifying the download's
+        # signature, so a failed cosign/Rekor check (transient upstream
+        # flake) leaves a stale empty dir that would make a bare retry
+        # skip reinstalling and fail differently. Clear it before retrying.
+        if: steps.chart-testing-setup.outcome == 'failure'
+        run: rm -rf "${RUNNER_TOOL_CACHE}/ct"
+      - name: Retry chart-testing setup
+        if: steps.chart-testing-setup.outcome == 'failure'
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f #v2.8.0
         with:
           version: v3.10.1

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.12.0-rc.3
+version: 0.12.0-rc.4
 appVersion: 1.12.0-rc16
 description: MLRun Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mlrun-ce
 version: 0.12.0-rc.4
-appVersion: 1.12.0-rc16
+appVersion: 1.12.0-rc18
 description: MLRun Open Source Stack
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png

--- a/charts/mlrun-ce/templates/_helpers.tpl
+++ b/charts/mlrun-ce/templates/_helpers.tpl
@@ -151,13 +151,6 @@ S3 Service Port - returns the port for pipeline config
 {{- end -}}
 
 {{/*
-S3 Region - required by the AWS CLI in the s3-bucket-init job
-*/}}
-{{- define "mlrun-ce.s3.region" -}}
-{{- .Values.seaweedfs.s3.region -}}
-{{- end -}}
-
-{{/*
 S3 Access Key - for MLRun and Jupyter.
 In "local" mode uses the internal SeaweedFS credential (storage.local.accessKey).
 In "s3" mode uses the external AWS credential (storage.s3.accessKey).

--- a/charts/mlrun-ce/templates/_helpers.tpl
+++ b/charts/mlrun-ce/templates/_helpers.tpl
@@ -151,6 +151,13 @@ S3 Service Port - returns the port for pipeline config
 {{- end -}}
 
 {{/*
+S3 Region - required by the AWS CLI in the s3-bucket-init job
+*/}}
+{{- define "mlrun-ce.s3.region" -}}
+{{- .Values.seaweedfs.s3.region -}}
+{{- end -}}
+
+{{/*
 S3 Access Key - for MLRun and Jupyter.
 In "local" mode uses the internal SeaweedFS credential (storage.local.accessKey).
 In "s3" mode uses the external AWS credential (storage.s3.accessKey).

--- a/charts/mlrun-ce/templates/seaweedfs/s3-bucket-init-job.yaml
+++ b/charts/mlrun-ce/templates/seaweedfs/s3-bucket-init-job.yaml
@@ -54,5 +54,5 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "aws s3 mb s3://$BUCKET_NAME 2>&1 || aws s3 ls s3://$BUCKET_NAME 2>&1 || exit 1"
+        - "aws s3 mb s3://$BUCKET_NAME 2>&1 || aws s3 ls s3://$BUCKET_NAME 2>&1 || { echo \"ERROR: Failed to create or verify bucket $BUCKET_NAME\"; exit 1; }"
 {{- end }}

--- a/charts/mlrun-ce/templates/seaweedfs/s3-bucket-init-job.yaml
+++ b/charts/mlrun-ce/templates/seaweedfs/s3-bucket-init-job.yaml
@@ -48,8 +48,6 @@ spec:
         # Without it, botocore attempts IMDS region discovery and crashes 
         - name: AWS_DEFAULT_REGION
           value: {{ include "mlrun-ce.s3.region" . | quote }}
-        - name: AWS_REGION
-          value: {{ include "mlrun-ce.s3.region" . | quote }}
         # Fully disable IMDS lookups as defense-in-depth, independent of region.
         - name: AWS_EC2_METADATA_DISABLED
           value: "true"

--- a/charts/mlrun-ce/templates/seaweedfs/s3-bucket-init-job.yaml
+++ b/charts/mlrun-ce/templates/seaweedfs/s3-bucket-init-job.yaml
@@ -45,9 +45,9 @@ spec:
         - name: BUCKET_NAME
           value: {{ include "mlrun-ce.seaweedfs.s3.bucket" . | quote }}
         # Region is required by the AWS CLI even though SeaweedFS ignores it.
-        # Without it, botocore attempts IMDS region discovery and crashes 
+        # Without it, botocore attempts IMDS region discovery and crashes (CEML-721).
         - name: AWS_DEFAULT_REGION
-          value: {{ include "mlrun-ce.s3.region" . | quote }}
+          value: "us-east-1"
         # Fully disable IMDS lookups as defense-in-depth, independent of region.
         - name: AWS_EC2_METADATA_DISABLED
           value: "true"

--- a/charts/mlrun-ce/templates/seaweedfs/s3-bucket-init-job.yaml
+++ b/charts/mlrun-ce/templates/seaweedfs/s3-bucket-init-job.yaml
@@ -44,8 +44,17 @@ spec:
           value: {{ include "mlrun-ce.s3.service.url" . | quote }}
         - name: BUCKET_NAME
           value: {{ include "mlrun-ce.seaweedfs.s3.bucket" . | quote }}
+        # Region is required by the AWS CLI even though SeaweedFS ignores it.
+        # Without it, botocore attempts IMDS region discovery and crashes 
+        - name: AWS_DEFAULT_REGION
+          value: {{ include "mlrun-ce.s3.region" . | quote }}
+        - name: AWS_REGION
+          value: {{ include "mlrun-ce.s3.region" . | quote }}
+        # Fully disable IMDS lookups as defense-in-depth, independent of region.
+        - name: AWS_EC2_METADATA_DISABLED
+          value: "true"
         command:
         - /bin/sh
         - -c
-        - "aws s3 mb s3://$BUCKET_NAME || aws s3 ls s3://$BUCKET_NAME || exit 1"
+        - "aws s3 mb s3://$BUCKET_NAME 2>&1 || aws s3 ls s3://$BUCKET_NAME 2>&1 || exit 1"
 {{- end }}

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -173,14 +173,14 @@ mlrun:
     enabled: false
   api:
     image:
-      tag: 1.12.0-rc16
+      tag: 1.12.0-rc18
     ingress:
       enabled: false
       annotations: {}
     sidecars:
       logCollector:
         image:
-          tag: 1.12.0-rc16
+          tag: 1.12.0-rc18
         enabled: true
     fullnameOverride: mlrun-api
     functionSpecServiceAccountDefault: ~
@@ -231,7 +231,7 @@ mlrun:
 
   ui:
     image:
-      tag: 1.12.0-rc16
+      tag: 1.12.0-rc18
     fullnameOverride: mlrun-ui
     ingress:
       enabled: false
@@ -300,7 +300,7 @@ jupyterNotebook:
     #      - chart-example.local
   image:
     repository: quay.io/mlrun/jupyter
-    tag: 1.12.0-rc16
+    tag: 1.12.0-rc18
     pullPolicy: IfNotPresent
     pullSecrets: []
   busybox:
@@ -385,9 +385,6 @@ seaweedfs:
   s3:
     port: 8333
     enableAuth: true
-    # Region for the s3-bucket-init job's AWS CLI calls. SeaweedFS ignores the
-    # region, but the AWS CLI requires one
-    region: us-east-1
 
   # Single-pod mode: master + volume + filer + S3 gateway in one deployment.
   # Reduces from 4 component pods down to 1, cutting CPU/memory footprint significantly.

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -385,6 +385,9 @@ seaweedfs:
   s3:
     port: 8333
     enableAuth: true
+    # Region for the s3-bucket-init job's AWS CLI calls. SeaweedFS ignores the
+    # region, but the AWS CLI requires one
+    region: us-east-1
 
   # Single-pod mode: master + volume + filer + S3 gateway in one deployment.
   # Reduces from 4 component pods down to 1, cutting CPU/memory footprint significantly.


### PR DESCRIPTION
### 📝 Description

Fixes [CEML-721](https://ecliptos.atlassian.net/browse/CEML-721): the `mlrun-ce-s3-bucket-init` post-install hook job fails on fresh installs because the `create-bucket` container runs `aws s3` without setting a region. Botocore then attempts EC2 IMDS region discovery inside the pod, which fails in most Kubernetes environments (especially Azure) and hits a long-standing botocore bug ([aws/aws-cli#8988](https://github.com/aws/aws-cli/issues/8988)) that prints a raw `<botocore.awsrequest.AWSRequest object at 0x...>` repr instead of a proper error. With `helm install --wait`, the failed hook causes the entire release to report FAILED.

---

### 🛠️ Changes Made

- Added `seaweedfs.s3.region: us-east-1` to `values.yaml` as the configurable region for the bucket-init job's AWS CLI calls
- Added `mlrun-ce.s3.region` helper in `_helpers.tpl`
- Set `AWS_DEFAULT_REGION` and `AWS_EC2_METADATA_DISABLED=true` on the `create-bucket` container in `s3-bucket-init-job.yaml`
- Redirected stderr to stdout (`2>&1`) on both `aws s3` commands so future failures produce readable log output
- Bumped chart version `0.12.0-rc.3` → `0.12.0-rc.4`

---

### ✅ Checklist
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes require a change in documentation and if so, I created another PR in MLRun for the relevant documentation.
- [ ] I confirmed whether my changes require a changes in QA tests, for example: credentials changes, resources naming change and if so, I updated the relevant Jira ticket for QA.
- [x] I increased the Chart version in `charts/mlrun-ce/Chart.yaml`.
- [ ] I confirmed that the installation works both on a local Docker Desktop environment and on a real cluster when using the required [prerequisites](https://docs.mlrun.org/en/stable/install-mlrun-ce/kubernetes-install.html#prerequisites).
  - [ ] If installation issues were found, I updated the relevant Jira ticket with the issue and steps to reproduce, or updated the prerequisites documentation if the issue is related to missing or outdated prerequisites.   
- [ ] If needed, update https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/README.md with the relevant installation instructions and version Matrix.
- [ ] If needed, update the following values files for multi namespace support:
  - [ ] [Admin values](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/admin_installation_values.yaml)
  - [ ] [User values Node Port](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/non_admin_installation_values.yaml)
  - [ ] [User values ClusterIP](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml)

---

### 🧪 Testing

- `helm template mlrun charts/mlrun-ce -f charts/mlrun-ce/values.yaml --show-only templates/seaweedfs/s3-bucket-init-job.yaml` — confirms `AWS_DEFAULT_REGION=us-east-1` and `AWS_EC2_METADATA_DISABLED=true` render correctly
- `helm lint charts/mlrun-ce` — passes (0 failed)

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/CEML-721
- External links: https://github.com/aws/aws-cli/issues/8988
- Design docs links (Optional):
---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

The existing `aws s3 mb || aws s3 ls` idempotency fallback is unchanged — it already handles the "bucket already exists" case from [CEML-698](https://ecliptos.atlassian.net/browse/CEML-698). This fix addresses a separate failure mode (IMDS region discovery) that reproduces on genuinely fresh installs with no pre-existing bucket.

No changes needed to the three install-mode values files — they only toggle `seaweedfs.enabled` and do not override `seaweedfs.s3`.

[CEML-698]: https://iguazio.atlassian.net/browse/CEML-698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ