### PR TITLE
[Fix] Protect TimescaleDB first boot with startupProbe

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.12.0-rc.4
+version: 0.12.0-rc.5
 appVersion: 1.12.0-rc18
 description: MLRun Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/templates/timescaledb/statefulset.yaml
+++ b/charts/mlrun-ce/templates/timescaledb/statefulset.yaml
@@ -54,15 +54,29 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
-          livenessProbe:
+          startupProbe:
             exec:
               command:
                 - pg_isready
+                - -h
+                - 127.0.0.1
                 - -U
                 - {{ .Values.timescaledb.auth.username }}
                 - -d
                 - {{ .Values.timescaledb.auth.database }}
-            initialDelaySeconds: 30
+            periodSeconds: {{ .Values.timescaledb.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.timescaledb.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.timescaledb.startupProbe.failureThreshold }}
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -h
+                - 127.0.0.1
+                - -U
+                - {{ .Values.timescaledb.auth.username }}
+                - -d
+                - {{ .Values.timescaledb.auth.database }}
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 6
@@ -70,11 +84,12 @@ spec:
             exec:
               command:
                 - pg_isready
+                - -h
+                - 127.0.0.1
                 - -U
                 - {{ .Values.timescaledb.auth.username }}
                 - -d
                 - {{ .Values.timescaledb.auth.database }}
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 6

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -647,7 +647,7 @@ timescaledb:
   startupProbe:
     periodSeconds: 10
     timeoutSeconds: 5
-    failureThreshold: 30
+    failureThreshold: 30  # 30 × 10 s = 5-min window for initdb on slow storage
   persistence:
     enabled: true
     size: "10Gi"

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -644,6 +644,10 @@ timescaledb:
     username: postgres
     password: postgres
     database: postgres
+  startupProbe:
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
   persistence:
     enabled: true
     size: "10Gi"


### PR DESCRIPTION
### 📝 Description
Stops TimescaleDB from being killed by the liveness probe during first-boot `initdb` on slow storage.

Without a `startupProbe`, Kubernetes can interrupt initialization and leave a corrupt `PGDATA` (missing `global/pg_filenode.map`), causing a permanent crash loop that breaks model-monitoring flows.

This change adds a configurable TimescaleDB `startupProbe` and forces probe checks over TCP (`-h 127.0.0.1`).

---

### 🛠️ Changes Made
- `charts/mlrun-ce/templates/timescaledb/statefulset.yaml`: added `startupProbe`; added `-h 127.0.0.1` to startup/liveness/readiness probes; removed `initialDelaySeconds` from liveness/readiness (gated by startup probe)
- `charts/mlrun-ce/values.yaml`: added `timescaledb.startupProbe` defaults (`periodSeconds: 10`, `timeoutSeconds: 5`, `failureThreshold: 30` → ~5 minute startup window)
- `charts/mlrun-ce/Chart.yaml`: bumped version `0.12.0-rc.4` → `0.12.0-rc.5`

---

### ✅ Checklist
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes require a change in documentation and if so, I created another PR in MLRun for the relevant documentation.
- [ ] I confirmed whether my changes require changes in QA tests, for example: credentials changes, resources naming change and if so, I updated the relevant Jira ticket for QA.
- [x] I increased the Chart version in `charts/mlrun-ce/Chart.yaml`.
- [ ] I confirmed that the installation works both on a local Docker Desktop environment and on a real cluster when using the required [prerequisites](https://docs.mlrun.org/en/stable/install-mlrun-ce/kubernetes-install.html#prerequisites).
  - [ ] If installation issues were found, I updated the relevant Jira ticket with the issue and steps to reproduce, or updated the prerequisites documentation if the issue is related to missing or outdated prerequisites.
- [x] If needed, update https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/README.md with the relevant installation instructions and version Matrix.
- [x] If needed, update the following values files for multi namespace support:
  - [x] [Admin values](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/admin_installation_values.yaml)
  - [x] [User values Node Port](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/non_admin_installation_values.yaml)
  - [x] [User values ClusterIP](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml)

---

### 🧪 Testing
- `helm lint charts/mlrun-ce` — passed
- `./tests/helm-template-test.sh` — 82/82 passed
- Full cluster `make tests` / Kind install — not run
- Manual reproduction of mid-`initdb` kill failure mode was documented on the Jira ticket

---

### 🔗 References
- Ticket link: 
- External links:
- Design docs links (Optional):

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Install-mode values files were not updated because `timescaledb.startupProbe` is a default inherited from `values.yaml`; admin install keeps `timescaledb.enabled: false`, and non-admin overlays do not need a probe override.

Jenkins deploy health-gate for TimescaleDB (ticket item 3) still lives in `ce-deployment` and is out of scope for this PR.
