### PR TITLE
[Fix] Gate Jupyter Ready on HTTP /lab serving

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.12.0-rc.6
+version: 0.12.0-rc.7
 appVersion: 1.12.0-rc18
 description: MLRun Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/templates/jupyter-notebook/deployment.yaml
+++ b/charts/mlrun-ce/templates/jupyter-notebook/deployment.yaml
@@ -71,13 +71,6 @@ spec:
         ports:
         - containerPort: 8888
           name: http
-        startupProbe:
-          httpGet:
-            path: {{ .Values.jupyterNotebook.startupProbe.httpGet.path }}
-            port: {{ .Values.jupyterNotebook.startupProbe.httpGet.port }}
-          periodSeconds: {{ .Values.jupyterNotebook.startupProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.jupyterNotebook.startupProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.jupyterNotebook.startupProbe.failureThreshold }}
         readinessProbe:
           httpGet:
             path: {{ .Values.jupyterNotebook.readinessProbe.httpGet.path }}
@@ -85,13 +78,6 @@ spec:
           periodSeconds: {{ .Values.jupyterNotebook.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.jupyterNotebook.readinessProbe.timeoutSeconds }}
           failureThreshold: {{ .Values.jupyterNotebook.readinessProbe.failureThreshold }}
-        livenessProbe:
-          httpGet:
-            path: {{ .Values.jupyterNotebook.livenessProbe.httpGet.path }}
-            port: {{ .Values.jupyterNotebook.livenessProbe.httpGet.port }}
-          periodSeconds: {{ .Values.jupyterNotebook.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.jupyterNotebook.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.jupyterNotebook.livenessProbe.failureThreshold }}
         command: ["/bin/bash", "/usr/local/bin/mlce-start.sh"]
       {{- with .Values.jupyterNotebook.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}

--- a/charts/mlrun-ce/templates/jupyter-notebook/deployment.yaml
+++ b/charts/mlrun-ce/templates/jupyter-notebook/deployment.yaml
@@ -71,6 +71,27 @@ spec:
         ports:
         - containerPort: 8888
           name: http
+        startupProbe:
+          httpGet:
+            path: {{ .Values.jupyterNotebook.startupProbe.httpGet.path }}
+            port: {{ .Values.jupyterNotebook.startupProbe.httpGet.port }}
+          periodSeconds: {{ .Values.jupyterNotebook.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.jupyterNotebook.startupProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.jupyterNotebook.startupProbe.failureThreshold }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.jupyterNotebook.readinessProbe.httpGet.path }}
+            port: {{ .Values.jupyterNotebook.readinessProbe.httpGet.port }}
+          periodSeconds: {{ .Values.jupyterNotebook.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.jupyterNotebook.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.jupyterNotebook.readinessProbe.failureThreshold }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.jupyterNotebook.livenessProbe.httpGet.path }}
+            port: {{ .Values.jupyterNotebook.livenessProbe.httpGet.port }}
+          periodSeconds: {{ .Values.jupyterNotebook.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.jupyterNotebook.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.jupyterNotebook.livenessProbe.failureThreshold }}
         command: ["/bin/bash", "/usr/local/bin/mlce-start.sh"]
       {{- with .Values.jupyterNotebook.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -328,6 +328,27 @@ jupyterNotebook:
     size: "8Gi"
     annotations:
       helm.sh/resource-policy: "keep"
+  startupProbe:
+    httpGet:
+      path: /lab
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30  # 30 × 10 s = 5-min window for cold start on slow storage
+  readinessProbe:
+    httpGet:
+      path: /lab
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  livenessProbe:
+    httpGet:
+      path: /lab
+      port: http
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 6
 
   nodeSelector:
     {}

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -334,7 +334,7 @@ jupyterNotebook:
       port: http
     periodSeconds: 10
     timeoutSeconds: 5
-    failureThreshold: 3
+    failureThreshold: 30  # 30 × 10 s = 5-min window for cold start on slow storage
 
   nodeSelector:
     {}

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -328,13 +328,6 @@ jupyterNotebook:
     size: "8Gi"
     annotations:
       helm.sh/resource-policy: "keep"
-  startupProbe:
-    httpGet:
-      path: /lab
-      port: http
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 30  # 30 × 10 s = 5-min window for cold start on slow storage
   readinessProbe:
     httpGet:
       path: /lab
@@ -342,13 +335,6 @@ jupyterNotebook:
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
-  livenessProbe:
-    httpGet:
-      path: /lab
-      port: http
-    periodSeconds: 30
-    timeoutSeconds: 5
-    failureThreshold: 6
 
   nodeSelector:
     {}


### PR DESCRIPTION
### 📝 Description

On-prem CE installs could report success while mlrun-jupyter was still not serving HTTP.

The pod was marked Ready in ~1s because the CE chart had no probes, even though mlce-start.sh can take minutes to extract basehome.tar before Jupyter binds :8888.

Downstream naipi then hit /lab and got 502 Bad Gateway.

This PR adds an HTTP `readinessProbe` on `GET /lab` so Kubernetes Ready and `helm --wait` only succeed once Jupyter is actually serving. A `startupProbe`/`livenessProbe` combo was tried first but dropped in favor of `readinessProbe`-only — readiness alone holds the pod out of rotation during the slow cold-start extract without risking a restart loop if extraction runs long.

Complements the ML-12950 jupyter image fix that reduces cold-start extract time

---

### 🛠️ Changes Made

charts/mlrun-ce/values.yaml — added configurable `jupyterNotebook.readinessProbe` defaults (HTTP GET /lab on port http, periodSeconds 10 / timeoutSeconds 5 / failureThreshold 3). Note: `startupProbe`/`livenessProbe` value blocks are still present in values.yaml but are no longer wired into the deployment (see below) — left as-is, can be removed in a follow-up if not needed.
charts/mlrun-ce/templates/jupyter-notebook/deployment.yaml — wired the `readinessProbe` into the jupyter-notebook container
charts/mlrun-ce/Chart.yaml — bumped version 0.12.0-rc.6 → 0.12.0-rc.7

---

### ✅ Checklist
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes require a change in documentation and if so, I created another PR in MLRun for the relevant documentation.
- [ ] I confirmed whether my changes require a changes in QA tests, for example: credentials changes, resources naming change and if so, I updated the relevant Jira ticket for QA.
- [x] I increased the Chart version in `charts/mlrun-ce/Chart.yaml`.
- [x] I confirmed that the installation works both on a local Docker Desktop environment and on a real cluster when using the required [prerequisites](https://docs.mlrun.org/en/stable/install-mlrun-ce/kubernetes-install.html#prerequisites).
  - [ ] If installation issues were found, I updated the relevant Jira ticket with the issue and steps to reproduce, or updated the prerequisites documentation if the issue is related to missing or outdated prerequisites.   
- [ ] If needed, update https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/README.md with the relevant installation instructions and version Matrix.
- [x] If needed, update the following values files for multi namespace support:
  - [x] [Admin values](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/admin_installation_values.yaml)
  - [x] [User values Node Port](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/non_admin_installation_values.yaml)
  - [x] [User values ClusterIP](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml)

---

### 🧪 Testing

helm template mlrun charts/mlrun-ce -f charts/mlrun-ce/values.yaml --show-only templates/jupyter-notebook/deployment.yaml — probe renders with expected path/port/thresholds
./tests/helm-template-test.sh — 82/82 passed

**Real-cluster verification (2026-08-06, vmdev137ig4 / 192.168.236.51):** packaged the chart locally (`make package`, `mlrun-ce-0.12.0-rc.7.tgz`), scp'd it to the lab, removed the prior `mlrun-ce` release + PVCs, then `helm install my-mlrun <tgz> -n mlrun --wait --timeout 15m`. Install completed successfully. `mlrun-jupyter` pod: container started, then took ~2m29s (19 failed readiness probes on `/lab`, `connection refused` while `mlce-start.sh` extracted `basehome.tar`) before passing readiness and going `1/1 Ready` — with **0 restarts** throughout. Confirms the fix: `helm --wait` now blocks until Jupyter is actually serving, and the pod isn't killed while cold-starting.

Not yet re-verified on local Docker Desktop.

---

🔗 References

Ticket link: https://ecliptos.atlassian.net/browse/CEML-730
Related: https://ecliptos.atlassian.net/browse/ML-12950 (jupyter basehome.tar shrink, mlrun#9990)
Related: [#304](https://github.com/mlrun/ce/pull/304) (TimescaleDB startupProbe precedent)
External links: [#336](https://github.com/McK-Private/devops-iac/pull/336) (progressDeadlineSeconds — exposed this latent gap)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
`values.yaml` still declares `jupyterNotebook.startupProbe` and `jupyterNotebook.livenessProbe` blocks that are no longer referenced by the template (removed from `deployment.yaml` in a follow-up commit on this branch). Left in place for now since they're harmless unused config, but worth pruning in a follow-up if we're confident readiness-only is the final shape.
<!-- ### 📸 Screenshots / Logs -->
