### PR TITLE
[Fix] Add CUDA-enabled Spark image

### DIFF
--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun-ce
-version: 0.12.0-rc.10
+version: 0.12.0-rc.11
 appVersion: 1.12.0-rc25
 description: MLRun Open Source Stack
 home: https://iguazio.com

--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -16,31 +16,8 @@ FROM spark:3.5.6-scala2.12-java17-ubuntu
 
 USER root
 
-RUN set -ex; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends software-properties-common curl ca-certificates gnupg; \
-    add-apt-repository -y ppa:deadsnakes/ppa; \
-    apt-get update; \
-    apt-get install -y python3.11 python3-distutils git; \
-    rm -rf /var/lib/apt/lists/*
-
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.11 get-pip.py
-
-RUN curl -f -o /opt/spark/jars/hadoop-aws-3.3.4.jar -LO https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar
-RUN curl -f -o /opt/spark/jars/aws-java-sdk-bundle-1.12.262.jar -LO https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar
-RUN curl -f -o /opt/spark/jars/wildfly-openssl-1.0.12.Final.jar -LO https://repo1.maven.org/maven2/org/wildfly/openssl/wildfly-openssl/1.0.12.Final/wildfly-openssl-1.0.12.Final.jar
-RUN curl -f -o /opt/spark/jars/gcs-connector-hadoop3-2.2.33-shaded.jar -LO https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.33/gcs-connector-hadoop3-2.2.33-shaded.jar
-RUN curl -f -o /opt/spark/jars/spark-bigquery-with-dependencies_2.12-0.43.1.jar -LO https://repo1.maven.org/maven2/com/google/cloud/spark/spark-bigquery-with-dependencies_2.12/0.43.1/spark-bigquery-with-dependencies_2.12-0.43.1.jar
-RUN curl -f -o /opt/spark/jars/hadoop-azure-3.3.4.jar -LO https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar
-RUN curl -f -o /opt/spark/jars/azure-storage-7.0.1.jar -LO https://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/7.0.1/azure-storage-7.0.1.jar
-RUN curl -f -o /opt/spark/jars/hadoop-common-3.3.4.jar -LO  https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-common/3.3.4/hadoop-common-3.3.4.jar
-RUN curl -f -o /opt/spark/jars/jetty-util-9.4.51.v20230217.jar -LO https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.51.v20230217/jetty-util-9.4.51.v20230217.jar
-RUN curl -f -o /opt/spark/jars/jetty-util-ajax-9.4.51.v20230217.jar -LO https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util-ajax/9.4.51.v20230217/jetty-util-ajax-9.4.51.v20230217.jar
-
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
-
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
-RUN mkdir /home/spark && chown spark /home/spark
+# Shared with the CUDA image.
+COPY scripts/ce-customize.sh /tmp/ce-customize.sh
+RUN chmod +x /tmp/ce-customize.sh && /tmp/ce-customize.sh && rm -f /tmp/ce-customize.sh
 
 USER spark

--- a/docker/spark/Dockerfile.cuda
+++ b/docker/spark/Dockerfile.cuda
@@ -1,0 +1,101 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# CUDA counterpart of ./Dockerfile using the same Spark distribution and
+# CE customization.
+
+ARG CUDA_VERSION=12.8.1
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu22.04
+
+ARG CUDA_VERSION
+
+LABEL com.iguazio.cuda-version="${CUDA_VERSION}" \
+      com.iguazio.cudnn-version="9.8.0.87-1"
+
+ARG spark_uid=185
+ARG TARGETARCH
+
+RUN groupadd --system --gid=${spark_uid} spark && \
+    useradd --system --uid=${spark_uid} --gid=spark spark
+
+# Match the upstream Spark image layout and add JDK 17.
+RUN set -ex; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        openjdk-17-jdk-headless gnupg2 wget bash tini libc6 libpam-modules \
+        krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
+    mkdir -p /opt/spark; \
+    mkdir /opt/spark/python; \
+    mkdir -p /opt/spark/examples; \
+    mkdir -p /opt/spark/work-dir; \
+    chmod g+w /opt/spark/work-dir; \
+    touch /opt/spark/RELEASE; \
+    chown -R spark:spark /opt/spark; \
+    echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH}
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Install the same GPG-verified Spark distribution as the upstream image.
+# https://downloads.apache.org/spark/KEYS
+ENV SPARK_TGZ_URL=https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz \
+    SPARK_TGZ_ASC_URL=https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz.asc \
+    GPG_KEY=0FE4571297AB84440673665669600C8338F65970
+
+RUN set -ex; \
+    export SPARK_TMP="$(mktemp -d)"; \
+    cd $SPARK_TMP; \
+    wget -nv -O spark.tgz "$SPARK_TGZ_URL"; \
+    wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-key "$GPG_KEY" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
+    gpg --batch --verify spark.tgz.asc spark.tgz; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" spark.tgz.asc; \
+    \
+    tar -xf spark.tgz --strip-components=1; \
+    chown -R spark:spark .; \
+    mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
+    mv bin /opt/spark/; \
+    mv sbin /opt/spark/; \
+    mv kubernetes/dockerfiles/spark/decom.sh /opt/; \
+    mv examples /opt/spark/; \
+    ln -s "$(basename /opt/spark/examples/jars/spark-examples_*.jar)" /opt/spark/examples/jars/spark-examples.jar; \
+    mv kubernetes/tests /opt/spark/; \
+    mv data /opt/spark/; \
+    mv python/pyspark /opt/spark/python/pyspark/; \
+    mv python/lib /opt/spark/python/lib/; \
+    mv R /opt/spark/; \
+    chmod a+x /opt/decom.sh; \
+    cd ..; \
+    rm -rf "$SPARK_TMP"
+
+COPY scripts/entrypoint.sh /opt/entrypoint.sh
+RUN chmod +x /opt/entrypoint.sh
+
+ENV SPARK_HOME=/opt/spark
+
+WORKDIR /opt/spark/work-dir
+
+# Shared with the regular image.
+COPY scripts/ce-customize.sh /tmp/ce-customize.sh
+RUN chmod +x /tmp/ce-customize.sh && /tmp/ce-customize.sh && rm -f /tmp/ce-customize.sh
+
+USER spark
+
+ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/docker/spark/Makefile
+++ b/docker/spark/Makefile
@@ -1,6 +1,29 @@
 MLRUN_CE_IMAGE_PLATFORM ?= linux/amd64
-MLRUN_CE_IMAGE_TAG ?= gcr.io/iguazio/spark-app:3.5.6-scala2.12-java17-ubuntu-1
+MLRUN_CE_SPARK_IMAGE_TAG ?= gcr.io/iguazio/spark-app:3.5.6-scala2.12-java17-ubuntu-1
+MLRUN_CE_SPARK_CUDA_IMAGE_TAG ?= gcr.io/iguazio/spark-app-cuda:3.5.6-scala2.12-java17-ubuntu-1
+CUDA_VERSION ?= 12.8.1
+
+# Kept for backward compatibility with the pre-CUDA workflow.
+MLRUN_CE_IMAGE_TAG ?= $(MLRUN_CE_SPARK_IMAGE_TAG)
 
 .PHONY: build
 build:
-	docker build --platform="$(MLRUN_CE_IMAGE_PLATFORM)" -t "$(MLRUN_CE_IMAGE_TAG)" .
+	docker build --platform="$(MLRUN_CE_IMAGE_PLATFORM)" -t "$(MLRUN_CE_IMAGE_TAG)" -f Dockerfile .
+
+.PHONY: build-cuda
+build-cuda:
+	docker build --platform="$(MLRUN_CE_IMAGE_PLATFORM)" --build-arg CUDA_VERSION="$(CUDA_VERSION)" -t "$(MLRUN_CE_SPARK_CUDA_IMAGE_TAG)" -f Dockerfile.cuda .
+
+.PHONY: build-all
+build-all: build build-cuda
+
+.PHONY: validate
+validate:
+	bash scripts/validate.sh "$(MLRUN_CE_IMAGE_TAG)"
+
+.PHONY: validate-cuda
+validate-cuda:
+	bash scripts/validate.sh "$(MLRUN_CE_SPARK_CUDA_IMAGE_TAG)" --cuda
+
+.PHONY: validate-all
+validate-all: validate validate-cuda

--- a/docker/spark/README.md
+++ b/docker/spark/README.md
@@ -1,0 +1,51 @@
+# CE Spark images
+
+This directory builds:
+
+- `gcr.io/iguazio/spark-app:3.5.6-scala2.12-java17-ubuntu-1` (`Dockerfile`) --
+  the regular CE Spark image.
+- `gcr.io/iguazio/spark-app-cuda:3.5.6-scala2.12-java17-ubuntu-1` (`Dockerfile.cuda`) --
+  the same Spark distribution and CE customization on CUDA 12.8.1/cuDNN 9.8.
+
+MLRun selects the CUDA image by appending `-cuda` to the configured repository.
+Both images share `scripts/ce-customize.sh`.
+
+## Build
+
+```bash
+make build
+make build-cuda
+make build-all
+```
+
+Override `MLRUN_CE_SPARK_IMAGE_TAG`, `MLRUN_CE_SPARK_CUDA_IMAGE_TAG`,
+`MLRUN_CE_IMAGE_PLATFORM`, or `CUDA_VERSION` as needed.
+
+## Validate
+
+These checks verify image contents and metadata without requiring a GPU.
+GPU visibility and Spark GPU scheduling require a GPU environment.
+
+```bash
+make validate
+make validate-cuda
+make validate-all
+```
+
+## Publish
+
+Build and validate the CUDA image, then push it manually:
+
+```bash
+make build-cuda
+make validate-cuda
+
+gcloud auth configure-docker gcr.io
+docker push gcr.io/iguazio/spark-app-cuda:3.5.6-scala2.12-java17-ubuntu-1
+
+docker inspect --format '{{index .RepoDigests 0}}' \
+  gcr.io/iguazio/spark-app-cuda:3.5.6-scala2.12-java17-ubuntu-1
+```
+
+Do not republish the existing regular image. Record the CUDA image digest and
+the CE source commit.

--- a/docker/spark/scripts/ce-customize.sh
+++ b/docker/spark/scripts/ce-customize.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Shared Python, connector JAR, and filesystem setup for both images.
+set -ex
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends software-properties-common curl ca-certificates gnupg
+add-apt-repository -y ppa:deadsnakes/ppa
+apt-get update
+apt-get install -y python3.11 python3-distutils git
+rm -rf /var/lib/apt/lists/*
+
+curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+python3.11 /tmp/get-pip.py
+rm -f /tmp/get-pip.py
+
+curl -f -o /opt/spark/jars/hadoop-aws-3.3.4.jar -LO https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar
+curl -f -o /opt/spark/jars/aws-java-sdk-bundle-1.12.262.jar -LO https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar
+curl -f -o /opt/spark/jars/wildfly-openssl-1.0.12.Final.jar -LO https://repo1.maven.org/maven2/org/wildfly/openssl/wildfly-openssl/1.0.12.Final/wildfly-openssl-1.0.12.Final.jar
+curl -f -o /opt/spark/jars/gcs-connector-hadoop3-2.2.33-shaded.jar -LO https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.33/gcs-connector-hadoop3-2.2.33-shaded.jar
+curl -f -o /opt/spark/jars/spark-bigquery-with-dependencies_2.12-0.43.1.jar -LO https://repo1.maven.org/maven2/com/google/cloud/spark/spark-bigquery-with-dependencies_2.12/0.43.1/spark-bigquery-with-dependencies_2.12-0.43.1.jar
+curl -f -o /opt/spark/jars/hadoop-azure-3.3.4.jar -LO https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar
+curl -f -o /opt/spark/jars/azure-storage-7.0.1.jar -LO https://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/7.0.1/azure-storage-7.0.1.jar
+curl -f -o /opt/spark/jars/hadoop-common-3.3.4.jar -LO https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-common/3.3.4/hadoop-common-3.3.4.jar
+curl -f -o /opt/spark/jars/jetty-util-9.4.51.v20230217.jar -LO https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.51.v20230217/jetty-util-9.4.51.v20230217.jar
+curl -f -o /opt/spark/jars/jetty-util-ajax-9.4.51.v20230217.jar -LO https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util-ajax/9.4.51.v20230217/jetty-util-ajax-9.4.51.v20230217.jar
+
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+ln -sf /usr/bin/python3 /usr/bin/python
+
+mkdir -p /home/spark
+chown spark /home/spark

--- a/docker/spark/scripts/entrypoint.sh
+++ b/docker/spark/scripts/entrypoint.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Vendored from https://github.com/apache/spark-docker, tag
+# 3.5.6/scala2.12-java17-ubuntu, so the CUDA image (whose nvidia/cuda base
+# does not ship this file) boots identically to the regular spark-app image.
+#
+# Prevent any errors from being silently ignored
+set -eo pipefail
+
+attempt_setup_fake_passwd_entry() {
+  # Check whether there is a passwd entry for the container UID
+  local myuid; myuid="$(id -u)"
+  # If there is no passwd entry for the container UID, attempt to fake one
+  # You can also refer to the https://github.com/docker-library/official-images/pull/13089#issuecomment-1534706523
+  # It's to resolve OpenShift random UID case.
+  # See also: https://github.com/docker-library/postgres/pull/448
+  if ! getent passwd "$myuid" &> /dev/null; then
+      local wrapper
+      for wrapper in {/usr,}/lib{/*,}/libnss_wrapper.so; do
+        if [ -s "$wrapper" ]; then
+          NSS_WRAPPER_PASSWD="$(mktemp)"
+          NSS_WRAPPER_GROUP="$(mktemp)"
+          export LD_PRELOAD="$wrapper" NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+          local mygid; mygid="$(id -g)"
+          printf 'spark:x:%s:%s:${SPARK_USER_NAME:-anonymous uid}:%s:/bin/false\n' "$myuid" "$mygid" "$SPARK_HOME" > "$NSS_WRAPPER_PASSWD"
+          printf 'spark:x:%s:\n' "$mygid" > "$NSS_WRAPPER_GROUP"
+          break
+        fi
+      done
+  fi
+}
+
+if [ -z "$JAVA_HOME" ]; then
+  JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | awk '{print $3}')
+fi
+
+SPARK_CLASSPATH="$SPARK_CLASSPATH:${SPARK_HOME}/jars/*"
+for v in "${!SPARK_JAVA_OPT_@}"; do
+    SPARK_EXECUTOR_JAVA_OPTS+=( "${!v}" )
+done
+
+if [ -n "$SPARK_EXTRA_CLASSPATH" ]; then
+  SPARK_CLASSPATH="$SPARK_CLASSPATH:$SPARK_EXTRA_CLASSPATH"
+fi
+
+if ! [ -z "${PYSPARK_PYTHON+x}" ]; then
+    export PYSPARK_PYTHON
+fi
+if ! [ -z "${PYSPARK_DRIVER_PYTHON+x}" ]; then
+    export PYSPARK_DRIVER_PYTHON
+fi
+
+# If HADOOP_HOME is set and SPARK_DIST_CLASSPATH is not set, set it here so Hadoop jars are available to the executor.
+# It does not set SPARK_DIST_CLASSPATH if already set, to avoid overriding customizations of this value from elsewhere e.g. Docker/K8s.
+if [ -n "${HADOOP_HOME}"  ] && [ -z "${SPARK_DIST_CLASSPATH}"  ]; then
+  export SPARK_DIST_CLASSPATH="$($HADOOP_HOME/bin/hadoop classpath)"
+fi
+
+if ! [ -z "${HADOOP_CONF_DIR+x}" ]; then
+  SPARK_CLASSPATH="$HADOOP_CONF_DIR:$SPARK_CLASSPATH";
+fi
+
+if ! [ -z "${SPARK_CONF_DIR+x}" ]; then
+  SPARK_CLASSPATH="$SPARK_CONF_DIR:$SPARK_CLASSPATH";
+elif ! [ -z "${SPARK_HOME+x}" ]; then
+  SPARK_CLASSPATH="$SPARK_HOME/conf:$SPARK_CLASSPATH";
+fi
+
+# SPARK-43540: add current working directory into executor classpath
+SPARK_CLASSPATH="$SPARK_CLASSPATH:$PWD"
+
+# Switch to spark if no USER specified (root by default) otherwise use USER directly
+switch_spark_if_root() {
+  if [ $(id -u) -eq 0 ]; then
+    echo gosu spark
+  fi
+}
+
+case "$1" in
+  driver)
+    shift 1
+    CMD=(
+      "$SPARK_HOME/bin/spark-submit"
+      --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
+      --conf "spark.executorEnv.SPARK_DRIVER_POD_IP=$SPARK_DRIVER_BIND_ADDRESS"
+      --deploy-mode client
+      "$@"
+    )
+    attempt_setup_fake_passwd_entry
+    # Execute the container CMD under tini for better hygiene
+    exec $(switch_spark_if_root) /usr/bin/tini -s -- "${CMD[@]}"
+    ;;
+  executor)
+    shift 1
+    CMD=(
+      ${JAVA_HOME}/bin/java
+      "${SPARK_EXECUTOR_JAVA_OPTS[@]}"
+      -Xms"$SPARK_EXECUTOR_MEMORY"
+      -Xmx"$SPARK_EXECUTOR_MEMORY"
+      -cp "$SPARK_CLASSPATH:$SPARK_DIST_CLASSPATH"
+      org.apache.spark.scheduler.cluster.k8s.KubernetesExecutorBackend
+      --driver-url "$SPARK_DRIVER_URL"
+      --executor-id "$SPARK_EXECUTOR_ID"
+      --cores "$SPARK_EXECUTOR_CORES"
+      --app-id "$SPARK_APPLICATION_ID"
+      --hostname "$SPARK_EXECUTOR_POD_IP"
+      --resourceProfileId "$SPARK_RESOURCE_PROFILE_ID"
+      --podName "$SPARK_EXECUTOR_POD_NAME"
+    )
+    attempt_setup_fake_passwd_entry
+    # Execute the container CMD under tini for better hygiene
+    exec $(switch_spark_if_root) /usr/bin/tini -s -- "${CMD[@]}"
+    ;;
+
+  *)
+    # Non-spark-on-k8s command provided, proceeding in pass-through mode...
+    exec "$@"
+    ;;
+esac

--- a/docker/spark/scripts/validate.sh
+++ b/docker/spark/scripts/validate.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Local image checks that do not require a GPU.
+
+set -euo pipefail
+
+IMAGE="${1:?usage: validate.sh <image> [--cuda]}"
+CUDA_MODE="${2:-}"
+
+EXPECTED_JARS=(
+  hadoop-aws-3.3.4.jar
+  aws-java-sdk-bundle-1.12.262.jar
+  wildfly-openssl-1.0.12.Final.jar
+  gcs-connector-hadoop3-2.2.33-shaded.jar
+  spark-bigquery-with-dependencies_2.12-0.43.1.jar
+  hadoop-azure-3.3.4.jar
+  azure-storage-7.0.1.jar
+  hadoop-common-3.3.4.jar
+  jetty-util-9.4.51.v20230217.jar
+  jetty-util-ajax-9.4.51.v20230217.jar
+)
+
+run() {
+  docker run --rm --platform "${MLRUN_CE_IMAGE_PLATFORM:-linux/amd64}" --entrypoint bash "$IMAGE" -c "$1"
+}
+
+echo "==> [$IMAGE] preserves the Spark entrypoint"
+entrypoint="$(docker inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')"
+[[ "$entrypoint" == '["/opt/entrypoint.sh"]' ]] || { echo "FAIL: unexpected entrypoint: '$entrypoint'"; exit 1; }
+
+echo "==> [$IMAGE] runs as the spark user"
+whoami="$(run 'whoami')"
+[[ "$whoami" == "spark" ]] || { echo "FAIL: expected spark user, got '$whoami'"; exit 1; }
+
+echo "==> [$IMAGE] Java 17"
+java_version="$(run 'java -version 2>&1')"
+grep -q 'version "17\.' <<<"$java_version" || { echo "FAIL: Java is not version 17:"; echo "$java_version"; exit 1; }
+
+echo "==> [$IMAGE] Spark 3.5.6 / Scala 2.12"
+spark_version="$(run '$SPARK_HOME/bin/spark-submit --version 2>&1')"
+grep -q 'version 3.5.6' <<<"$spark_version" || { echo "FAIL: Spark is not version 3.5.6:"; echo "$spark_version"; exit 1; }
+grep -q 'Scala version 2.12' <<<"$spark_version" || { echo "FAIL: Scala is not version 2.12:"; echo "$spark_version"; exit 1; }
+
+echo "==> [$IMAGE] Python 3.11"
+python_version="$(run 'python3 --version 2>&1')"
+grep -q 'Python 3.11' <<<"$python_version" || { echo "FAIL: Python is not version 3.11: $python_version"; exit 1; }
+
+echo "==> [$IMAGE] connector JARs"
+for jar in "${EXPECTED_JARS[@]}"; do
+  run "test -f \$SPARK_HOME/jars/$jar" || { echo "FAIL: missing jar $jar"; exit 1; }
+done
+
+if [[ "$CUDA_MODE" == "--cuda" ]]; then
+  expected_cuda_version="$(docker inspect "$IMAGE" --format '{{index .Config.Labels "com.iguazio.cuda-version"}}')"
+  [[ -n "$expected_cuda_version" ]] || { echo "FAIL: CUDA version label is missing"; exit 1; }
+
+  echo "==> [$IMAGE] CUDA $expected_cuda_version runtime"
+  cuda_env="$(docker inspect "$IMAGE" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^CUDA_VERSION=' || true)"
+  [[ "$cuda_env" == "CUDA_VERSION=$expected_cuda_version" ]] || { echo "FAIL: unexpected CUDA_VERSION: '$cuda_env'"; exit 1; }
+  cuda_toolkit_version="${expected_cuda_version%.*}"
+  nvcc_version="$(run 'nvcc --version 2>&1')"
+  grep -Fq "release $cuda_toolkit_version" <<<"$nvcc_version" || { echo "FAIL: CUDA toolkit is not $cuda_toolkit_version: $nvcc_version"; exit 1; }
+
+  echo "==> [$IMAGE] cuDNN 9.8 libraries present"
+  run 'ldconfig -p | grep -q libcudnn.so.9' || { echo "FAIL: libcudnn.so.9 not found"; exit 1; }
+
+  echo "==> [$IMAGE] NVIDIA_VISIBLE_DEVICES=all"
+  visible_devices="$(docker inspect "$IMAGE" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^NVIDIA_VISIBLE_DEVICES=' || true)"
+  [[ "$visible_devices" == "NVIDIA_VISIBLE_DEVICES=all" ]] || { echo "FAIL: unexpected NVIDIA_VISIBLE_DEVICES: '$visible_devices'"; exit 1; }
+
+  echo "==> [$IMAGE] NVIDIA_DRIVER_CAPABILITIES=compute,utility"
+  caps="$(docker inspect "$IMAGE" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^NVIDIA_DRIVER_CAPABILITIES=' || true)"
+  [[ "$caps" == "NVIDIA_DRIVER_CAPABILITIES=compute,utility" ]] || { echo "FAIL: unexpected NVIDIA_DRIVER_CAPABILITIES: '$caps'"; exit 1; }
+fi
+
+echo "==> [$IMAGE] all checks passed"


### PR DESCRIPTION
### 📝 Description

Adds the CUDA-enabled Spark image required when MLRun requests GPU resources for Spark drivers or executors.

The image matches the existing CE Spark 3.5.6 stack while adding CUDA 12.8.1 and cuDNN 9.8.

---

### 🛠️ Changes Made

- Added `docker/spark/Dockerfile.cuda` based on `nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04`.
- Shared Python 3.11, connector JAR, and filesystem setup through `docker/spark/scripts/ce-customize.sh`.
- Added CUDA build and validation targets to `docker/spark/Makefile`.
- Added local checks for Spark, Scala, Java, Python, connector JARs, CUDA, cuDNN, and NVIDIA container metadata.
- Documented image build, validation, and manual GCR publication in `docker/spark/README.md`.
- Bumped the chart version from `0.12.0-rc.10` to `0.12.0-rc.11`.

---

### ✅ Checklist

- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes require a change in documentation and if so, I created another PR in MLRun for the relevant documentation.
- [ ] I confirmed whether my changes require a changes in QA tests, for example: credentials changes, resources naming change and if so, I updated the relevant Jira ticket for QA.
- [x] I increased the Chart version in `charts/mlrun-ce/Chart.yaml`.
- [ ] I confirmed that the installation works both on a local Docker Desktop environment and on a real cluster when using the required [prerequisites](https://docs.mlrun.org/en/stable/install-mlrun-ce/kubernetes-install.html#prerequisites).
  - [ ] If installation issues were found, I updated the relevant Jira ticket with the issue and steps to reproduce, or updated the prerequisites documentation if the issue is related to missing or outdated prerequisites.
- [x] If needed, update https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/README.md with the relevant installation instructions and version Matrix.
- [x] If needed, update the following values files for multi namespace support:
  - [x] [Admin values](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/admin_installation_values.yaml)
  - [x] [User values Node Port](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/non_admin_installation_values.yaml)
  - [x] [User values ClusterIP](https://github.com/mlrun/ce/blob/development/charts/mlrun-ce/non_admin_cluster_ip_installation_values.yaml)

---

### 🧪 Testing

- Built the `linux/amd64` CUDA image with `make -C docker/spark build-cuda`.
- Ran `make -C docker/spark validate-cuda`.
- Verified Spark 3.5.6, Scala 2.12, Java 17, Python 3.11, connector JARs, CUDA 12.8.1, cuDNN 9.8, the Spark entrypoint, and NVIDIA container metadata.
- GPU device visibility and Spark driver/executor startup still require validation in an ORIS GPU environment.

---

### 🔗 References

- Ticket link: ORIS-4194
- External links: [Apache Spark Docker images](https://github.com/apache/spark-docker), [NVIDIA CUDA container images](https://hub.docker.com/r/nvidia/cuda)
- Design docs links (Optional): N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- The CUDA image is published manually because this repository has no provisioned GCR publishing credentials.
- Adding the image to the Mlefi release manifest and validating the GPU Spark scenario are follow-up tasks.